### PR TITLE
Small typo fixed in 2019-02-26-python37-openssl.md

### DIFF
--- a/_posts/2019-02-26-python37-openssl.md
+++ b/_posts/2019-02-26-python37-openssl.md
@@ -108,7 +108,7 @@ You should see the following lines COMMENTED.
 ```
 # Socket module helper for SSL support; you must comment out the other
 # socket line above, and possibly edit the SSL variable:
-:SSL=/usr/local/ssl
+SSL=/usr/local/ssl
  _ssl _ssl.c \
     -DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \
     -L$(SSL)/lib -lssl -lcrypto


### PR DESCRIPTION
I found a colon just before the SSL setting at line 111. When I removed it the process worked
Thank you so much for this post; I'd been trying for a couple of hours to fix this!