### PR TITLE
Enable Copilot Knowledge Base

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+<!-- github-knowledge-base-start -->
+## Knowledge Base
+
+### Purpose
+
+This repository uses the Knowledge Base at [https://github.com/joshspicer/joshspicer.github.io](https://github.com/joshspicer/joshspicer.github.io) on branch `master`.
+
+### Required behavior
+
+1. Before changing code, read `docs/index.md` from that branch.
+2. Use the index to open only the knowledge files relevant to the task.
+3. If the index is unavailable, stop and report that the Knowledge Base could not be loaded.
+
+### Source of truth
+
+Generated knowledge tracks the code. When the knowledge and code disagree, trust the code.
+<!-- github-knowledge-base-end -->

--- a/.github/knowledge-base.json
+++ b/.github/knowledge-base.json
@@ -1,0 +1,10 @@
+{
+  "schema": "2.0",
+  "docs_system": "joshspicer.github.io",
+  "working_repos": [
+    {
+      "repo": "self"
+    }
+  ]
+}
+

--- a/.github/workflows/knowledge-base-issue-artifact.yml
+++ b/.github/workflows/knowledge-base-issue-artifact.yml
@@ -1,0 +1,67 @@
+name: Attach Knowledge Base artifact
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  attach:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@v4
+
+      - name: Attach Knowledge Base instructions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          [[ -f AGENTS.md ]] || { echo "::error file=AGENTS.md::Knowledge Base instructions are missing"; exit 1; }
+          [[ -f .github/knowledge-base.json ]] || { echo "::error file=.github/knowledge-base.json::Knowledge Base manifest is missing"; exit 1; }
+
+          knowledge_base_instructions="$(
+            awk -v start='<!-- github-knowledge-base-start -->' -v finish='<!-- github-knowledge-base-end -->' '
+              $0 == start { if (++starts == 1) copying = 1; else exit 1 }
+              copying { print }
+              $0 == finish { if (copying == 1 && ++ends == 1) copying = 0; else exit 1 }
+              END { if (starts == 1 && ends == 1 && copying == 0) exit 0; exit 1 }
+            ' AGENTS.md
+          )" || {
+            echo "::error file=AGENTS.md::Expected exactly one managed Knowledge Base section"
+            exit 1
+          }
+
+          docs_system="$(jq -er '.docs_system | select(type == "string" and length > 0)' .github/knowledge-base.json)" || {
+            echo "::error file=.github/knowledge-base.json::docs_system must be a non-empty string"
+            exit 1
+          }
+          artifact_name="Knowledge Base: $docs_system"
+          artifact_body="$knowledge_base_instructions"
+
+          artifacts="$(gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/artifacts")"
+          mapfile -t matching_numbers < <(
+            jq -r --arg name "$artifact_name" '.[] | select(.type == "generic" and .name == $name) | .number' <<<"$artifacts"
+          )
+
+          if [[ "${#matching_numbers[@]}" -gt 0 ]]; then
+            artifact_number="${matching_numbers[0]}"
+            gh api --method PATCH "repos/$REPOSITORY/issues/$ISSUE_NUMBER/artifacts/$artifact_number" \
+              --raw-field name="$artifact_name" \
+              --raw-field body="$artifact_body"
+
+            for duplicate_number in "${matching_numbers[@]:1}"; do
+              gh api --method DELETE "repos/$REPOSITORY/issues/$ISSUE_NUMBER/artifacts/$duplicate_number"
+            done
+          else
+            gh api --method POST "repos/$REPOSITORY/issues/$ISSUE_NUMBER/artifacts" \
+              --raw-field type="generic" \
+              --raw-field name="$artifact_name" \
+              --raw-field body="$artifact_body"
+          fi

--- a/.github/workflows/knowledge-base.yml
+++ b/.github/workflows/knowledge-base.yml
@@ -1,0 +1,26 @@
+# Keeps the Knowledge Base in sync with the codebase.
+#
+# Runs each weekday or when started manually. The reusable workflow reads
+# .github/knowledge-base.json, updates the knowledge docs, and opens a pull
+# request if anything changed.
+#
+# To change the schedule, edit the cron expression below.
+
+name: Update Knowledge Base
+
+on:
+  schedule:
+    - cron: "0 8 * * 1-5"
+  workflow_dispatch: {}
+
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+  copilot-requests: write
+
+jobs:
+  update-knowledge-base:
+    uses: github/agentic-knowledge-base/.github/workflows/knowledge-base-engine.lock.yml@main
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+<!-- github-knowledge-base-start -->
+## Knowledge Base
+
+### Purpose
+
+This repository uses the Knowledge Base at [https://github.com/joshspicer/joshspicer.github.io](https://github.com/joshspicer/joshspicer.github.io) on branch `master`.
+
+### Required behavior
+
+1. Before changing code, read `docs/index.md` from that branch.
+2. Use the index to open only the knowledge files relevant to the task.
+3. If the index is unavailable, stop and report that the Knowledge Base could not be loaded.
+
+### Source of truth
+
+Generated knowledge tracks the code. When the knowledge and code disagree, trust the code.
+<!-- github-knowledge-base-end -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# joshspicer/joshspicer.github.io
+
+> Routing index for the knowledge base. Copilot reads this file to decide
+> which docs to open for a given task. Keep entries short — one line per doc.
+
+| When working on | Topics | Read |
+|---|---|---|
+| Any task in this repo | general | (no docs yet — the sync workflow will populate this table after merge) |


### PR DESCRIPTION
## Knowledge Base setup

Created from repository settings by @joshspicer.

Adds Knowledge Base configuration and weekday updates for `joshspicer/joshspicer.github.io`.

| Adds | Purpose |
| --- | --- |
| `.github/knowledge-base.json` | Sources, scope, and schedule |
| `.github/workflows/knowledge-base.yml` | Weekday knowledge updates |
| `.github/workflows/knowledge-base-issue-artifact.yml` | Knowledge instructions on new issues |
| `docs/index.md` | Knowledge routing index |
| `AGENTS.md` | Discovery for compatible agents |
| `.github/copilot-instructions.md` | Discovery for Copilot |

### Authentication

| Token | Purpose | Setup |
| --- | --- | --- |
| `GITHUB_TOKEN` | Writes the rolling pull request and diagnostic issues | None. The workflow permissions grant access. |
| `GH_AW_GITHUB_TOKEN` | Reads the tracking repository and repositories in `working_repos` | Required only when any of these repositories is private. Use a read-only fine-grained personal access token with **Contents: Read**, **Issues: Read**, and **Pull requests: Read**. |

## Create Knowledge Documents with an agent

Have ready:
- The **repo(s) your team ships code to**
- A link to your **project board or tracking issue** if applicable

In an agent session, copy the prompt below and paste in this pull request URL:

```text
For this pull request [PR_URL_HERE] use the gh api to follow the instructions from https://api.github.com/repos/github/agentic-knowledge-base/contents/knowledge-base-setup-guide.md
```

The agent will guide you through a few questions and build the docs. No install or extra prompting needed!

**When you're finished:**
- This experience is still being iterated on. With your permission, the agent will synthesize notes at the end of your session and record any optional feedback you choose to give.
-  To learn how Knowledge Base keeps itself up to date — and more — see the [About Knowledge Base](https://gh.io/about-knowledge-base) documentation.
