### PR TITLE
Add portrait to site footer

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -7,7 +7,15 @@ import SocialIcon from './SocialIcon.astro';
 
 <footer class="site-footer">
   <div class="footer-meta">
-    <span>&copy; {new Date().getFullYear()} {siteConfig.name}</span>
+    <img
+      class="footer-portrait"
+      src={withBase('/assets/portrait.jpg')}
+      alt={`Portrait of ${siteConfig.name}`}
+      width="792"
+      height="792"
+      loading="lazy"
+      decoding="async"
+    />
     <div class="footer-settings" data-settings hidden>
       <button
         type="button"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -638,6 +638,16 @@ input {
   align-items: center;
 }
 
+.footer-portrait {
+  flex: none;
+  display: block;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  object-fit: cover;
+}
+
 .footer-settings {
   position: relative;
 }

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -635,10 +635,10 @@ test('dark theme text and every highlight tone meet contrast requirements', asyn
   }
 });
 
-test('portrait-free homepage and footer remain responsive', async ({ page }) => {
+test('homepage and footer remain responsive', async ({ page }) => {
   await page.goto('/');
 
-  await expect(page.locator('.portrait')).toHaveCount(0);
+  await expect(page.locator('.site-footer .footer-portrait')).toBeVisible();
   await expect(
     page.getByRole('region', { name: 'Josh Spicer' }).getByRole('heading', {
       name: 'Josh Spicer',


### PR DESCRIPTION
Restores the portrait avatar (removed during the Astro migration) back to the site, in the footer so it appears on every page.

## What changed
- Show `public/assets/portrait.jpg` as a circular avatar in the footer (`SiteFooter.astro`)
- Remove the `© <year> Josh Spicer` copyright line for a cleaner footer — portrait + site-settings toggle on the left, social links on the right
- Add `.footer-portrait` styling: 2rem circle with a theme-aware border; lazy-loaded with explicit width/height to avoid layout shift
- Update the footer responsiveness e2e test to assert the footer portrait is visible (previously it asserted the portrait was absent)

## Verification
- `astro check`: 0 errors / 0 warnings
- `astro build`: succeeds
- Playwright e2e suite: 27/27 passing
- Spot-checked light/dark themes and desktop/mobile layouts

_Tip: on the compare page, use the **Create pull request** dropdown → **Create draft pull request**._
