### PR TITLE
Rework article media: figures, galleries, deep links, responsive images

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,7 @@
 import { defineConfig } from 'astro/config';
+import { satteri } from '@astrojs/markdown-satteri';
+import { proseMedia } from './src/plugins/proseMedia.mjs';
+import { responsiveImages } from './src/integrations/responsiveImages.mjs';
 
 const [, repository = ''] = (
   process.env.GITHUB_REPOSITORY ?? '/'
@@ -11,6 +14,14 @@ export default defineConfig({
   base:
     process.env.BASE_PATH ??
     (repository && !isUserOrOrganizationSite ? `/${repository}` : '/'),
+  markdown: {
+    processor: satteri({
+      hastPlugins: [
+        proseMedia({ publicDir: new URL('./public/', import.meta.url) }),
+      ],
+    }),
+  },
+  integrations: [responsiveImages()],
   vite: {
     server: {
       proxy: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
+        "@astrojs/markdown-satteri": "^0.3.5",
         "@playwright/test": "^1.62.1",
         "@types/node": "^26.2.0",
+        "sharp": "^0.35.3",
         "typescript": "^5.8.3"
       }
     },
@@ -1117,8 +1119,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4409,8 +4411,8 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
       "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
+    "@astrojs/markdown-satteri": "^0.3.5",
     "@playwright/test": "^1.62.1",
     "@types/node": "^26.2.0",
+    "sharp": "^0.35.3",
     "typescript": "^5.8.3"
   }
 }

--- a/src/content/blog/2017-08-17-cinnamon-photo-of-the-day.md
+++ b/src/content/blog/2017-08-17-cinnamon-photo-of-the-day.md
@@ -19,6 +19,7 @@ tags:
   var photo = "/assets/cinnamon/" + num + ".jpg"
   document.getElementById("cinnaImage").src = photo;
 ```
-<img style="border: 3px;border-style: solid;" class="cinnamon" id="cinnaImage" src=""/>
+
+<img class="cinnamon" id="cinnaImage" src="" alt="Cinnamon the cat, chosen for today" title="Today's Cinnamon"/>
 
 <script src="/js/whichCinnamon.js"></script>

--- a/src/content/blog/2017-12-17-colorful-motivation.md
+++ b/src/content/blog/2017-12-17-colorful-motivation.md
@@ -10,7 +10,7 @@ tags:
 > As of June 2018, Colorful Motivation has 300+ users on the [Chrome web store](https://chrome.google.com/webstore/detail/colorful-motivation-new-t/mebfadffaiadgfhoieipinanpcmklhil)!
 
 Replace your (boring and white) new tab page on Chrome with (fun and colorful) motivation. This extension displays your current age, and generates a background color based on that age.
-<br><br>
+
 ![img1](https://github.com/joshspicer/colorful-motivation/raw/master/time1.png)
 
 ![img2](https://github.com/joshspicer/colorful-motivation/raw/master/time2.png)

--- a/src/content/blog/2018-03-18-cryptopals.md
+++ b/src/content/blog/2018-03-18-cryptopals.md
@@ -12,7 +12,7 @@ tags:
 
 > I recently discovered the [cryptopals](http://cryptopals.com) crypto challenges by nccgroup. I'll be recording my solutions here.
 
-<h3>set1</h3>
+### set1
 ```python
 import sys
 from Crypto.Cipher import AES
@@ -285,5 +285,5 @@ howManyUniqueBlocks(fileEightArray)
 
 ```
 
-<h3>to be continued....</h3>
+### to be continued....
 ```

--- a/src/content/blog/2018-04-05-geo-fellowship.md
+++ b/src/content/blog/2018-04-05-geo-fellowship.md
@@ -7,31 +7,20 @@ tags:
   - travel
 ---
 
-<h4> Italy - Dialogue of Civilizations -  Summer 2017</h4>
+#### Italy - Dialogue of Civilizations -  Summer 2017
    <br>
 
-   <img class="geo-fellowship-photo" src="/assets/fellowship/1.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/2.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/3.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/4.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/5.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/6.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/7.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/8.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/9.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/10.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/11.png"  />
-
-   <img class="geo-fellowship-photo" src="/assets/fellowship/12.png"  />
+![Photo 1 of 12 from the Florence, Italy program](/assets/fellowship/1.png)
+![Photo 2 of 12 from the Florence, Italy program](/assets/fellowship/2.png)
+![Photo 3 of 12 from the Florence, Italy program](/assets/fellowship/3.png)
+![Photo 4 of 12 from the Florence, Italy program](/assets/fellowship/4.png)
+![Photo 5 of 12 from the Florence, Italy program](/assets/fellowship/5.png)
+![Photo 6 of 12 from the Florence, Italy program](/assets/fellowship/6.png)
+![Photo 7 of 12 from the Florence, Italy program](/assets/fellowship/7.png)
+![Photo 8 of 12 from the Florence, Italy program](/assets/fellowship/8.png)
+![Photo 9 of 12 from the Florence, Italy program](/assets/fellowship/9.png)
+![Photo 10 of 12 from the Florence, Italy program](/assets/fellowship/10.png)
+![Photo 11 of 12 from the Florence, Italy program](/assets/fellowship/11.png)
+![Photo 12 of 12 from the Florence, Italy program](/assets/fellowship/12.png)
 
 <!-- <script src="https://gist.github.com/kjbrum/5d90663036d64e5f5c9f.js"></script> -->

--- a/src/content/blog/2018-06-28-root-pixel-1-verizon.md
+++ b/src/content/blog/2018-06-28-root-pixel-1-verizon.md
@@ -19,7 +19,7 @@ I was hoping to eventually root the device in order to play around with some pen
 to find an easy solution _until now_.
 <br><br>
 
-<h2>Unlock Bootloader</h2>
+## Unlock Bootloader
 
 This morning I saw a [post](https://forum.xda-developers.com/pixel-xl/how-to/how-to-unlock-bootloader-verizon-pixel-t3796030) on the xda forums by user **burduli**,
 illustrating how he unlocked the bootloader on a Verizon Pixel. His article was posted on May 27th, 2018. It's taken almost **two years** since the phone's release for this simple bootloader workaround to be found!
@@ -42,7 +42,7 @@ The steps are as follows, adapted slightly based on my experience and environmen
     `fastboot flashing unlock`
 11. Profit
 
-<h3>Notes</h3>
+### Notes
 - For `adb` and `fastboot`, I installed Android Studio on my machine and navigated to `~/Android/Sdk/platform-tools` when I wanted to use those programs. I had difficulty with the `fastboot` installed from apt that was attached to my PATH.
 <br><br>
 - I had to restart my phone twice to perform step 9. The first time, the OEM unlocking slider was grayed out. Others in the original post's comments had similar problems.
@@ -51,7 +51,7 @@ The steps are as follows, adapted slightly based on my experience and environmen
 <br><br>
 - Be aware that unlocking bootloader removes everything from your device. The fact that you factory restore in step 3 means you should be ok with this...
 
-<h2>Rooting Prereqs</h2>
+## Rooting Prereqs
 
 These are the requirements and files I found necessary.
 
@@ -62,7 +62,7 @@ These are the requirements and files I found necessary.
 - [twrp-pixel-installer-sailfish-3.2.1-2.zip](https://dl.twrp.me/sailfish/twrp-pixel-installer-sailfish-3.2.1-2.zip.html) (downloaded to **device file system** BEFORE starting)
 - [Magisk](https://forum.xda-developers.com/apps/magisk/official-magisk-v7-universal-systemless-t3473445) (downloaded to **device file system** BEFORE starting)
 
-<h2>Get rid of all the Verizon</h2>
+## Get rid of all the Verizon
 
 Now i'm not positive if this step is essential, but after encountering difficulty I decided to reimage the phone with an official Google
 image. Either way, can't hurt to start with a clean slate.
@@ -71,7 +71,7 @@ Download the image above and follow this steps Google provides on their [factory
 Essentially, you'll want to unzip the image archive, plug in your device, and run the `flash-all.sh` it provides. You'll need to make sure the
 correct `fastboot` is in your PATH. Mine wasn't, so I modified the four spots that `fastboot` was called in the script and wrote out the full path (`~/Android/Sdk/platform-tools/fastboot`).
 
-<h2>Prep TWRP</h2>
+## Prep TWRP
 
 First off, make sure to set a PIN number in the OS before continuing. You need a PIN so TWRP can decrypt and access the file system later.
 <br><br>
@@ -82,7 +82,7 @@ Install the .img file from above, move it to your `platform-tools` folder and re
 
 `mv ~/Downloads/twrp-3.2.1-2-sailfish.img ~/Android/Sdk/platform-tools/twrp.img`
 
-<h2>Load TWRP</h2>
+## Load TWRP
 
 Now we're ready to load TWRP onto our phone. Start bootloader mode by holding down **power button + volume down** and plug in your phone. If you see an Android lying on his back, you're in the right spot. Try running `fastboot devices` - you should see your device show up.
 
@@ -92,7 +92,7 @@ Boot from the twrp image we just moved to the `platform-tools` directory by issu
 
 `fastboot boot twrp.img`
 
-<h2>Install TWRP</h2>
+## Install TWRP
 
 Great! You should now be booted into the twrp interface.
 
@@ -102,7 +102,7 @@ Press the "install" button, navigate to your Downloads folder, and install the `
 <br><br>
 Now go back a few steps to the page we started at, press the `restart` button, and then press `recovery`. You should now boot into a version of TWRP running entirely on your device. You can use TWRP to do a whole bunch of things...one of them being rooting the device.
 
-<h2>Actually root the device</h2>
+## Actually root the device
 
 Same as last time! Press the "install" button, but this time you're installing the `Magisk` zip you downloaded at the start of this guide.
 <br><br>

--- a/src/content/blog/2018-07-01-spotify-party-queue.md
+++ b/src/content/blog/2018-07-01-spotify-party-queue.md
@@ -11,7 +11,7 @@ tags:
   - music
 ---
 
-<h2>Intro</h2>
+## Intro
 
 I love discovering new music.
 <br><br>
@@ -24,7 +24,7 @@ step further, letting _anyone_ add to my queue.
 Well ok...not _exactly_ my queue. Song get added instead to a [playlist called "Josh's Public Queue"](https://open.spotify.com/user/joshspicer37/playlist/0OBq0h6EjCmaPXjeCB4IlM?si=6ZeWyAiRR0u51UJK-7Hb_g). You can follow and listen to that
 playlist, and of course add song recommendations through this site.
 
-<h2>How does it work!?</h2>
+## How does it work!?
 The backend service runs as an AWS Lambda function, just like my **[Spotify "now playing" post](/spotify-now-playing)**. That post will give you the background necessary in getting a Spotify client ID, as well as setting up AWS DynamoDB, API Gateway, and Lambda.
 
 <br>

--- a/src/content/blog/2018-07-08-android-hacking-with-frida.md
+++ b/src/content/blog/2018-07-08-android-hacking-with-frida.md
@@ -21,7 +21,7 @@ but i'm sure it'll be apparent once we get the app running.
 I have little experience with Frida, so this will be a complete beginner's walkthrough. For more detail
 on what Frida is, please check our their [documentation](https://frida.re/docs/home) first.
 
-<h2>Prereqs</h2>
+## Prereqs
 - Rooted Android Phone
 - [OWASP's First CrackMe APK](https://github.com/OWASP/owasp-mstg/tree/master/Crackmes)
 <br>
@@ -35,17 +35,17 @@ Check my [earlier article](/root-pixel-1) for how to root Pixel Phones.
 <br><br>
 Download the APK and sideload it onto your device. `adb install <APK>`
 
-<h2>Installing Frida</h2>
+## Installing Frida
 Installing Frida is pretty well-documented over at [Frida's project webpage](https://www.frida.re/docs/installation/).
 I worked off our my Macbook after installing with pip .
 
-<h2>frida-server</h2>
+## frida-server
 The easiest way to get up and running is to run the `frida-server` software directly on your rooted
 android phone. I again followed [their guide](https://www.frida.re/docs/android/) on that. I had difficulty escalating to root
 through adb, so I just downloaded a terminal app from the play store, became root through `su root`, and ran the server
 from there.
 
-<h2>Get started</h2>
+## Get started
 
 We're now ready to take a look at the .apk we're testing. Our goal is to reverse engineer the app enough to
 uncover the secret key. Our best bet is to see if we can understand what any of the decompiled code is doing.
@@ -69,7 +69,7 @@ On the left sidebar you'll see the hierarchical list of classes found in this .a
 there's only a few classes we have to worry about. In the center-left panel is the JD-GUI decompiled output.
 I've found this output to be pretty good, and will be referencing this output for the remainder of the article.
 
-<h2>Investigation: Root Detection</h2>
+## Investigation: Root Detection
 
 Hm, immediately after booting into the Android app, we hit a roadblock. There seems to be some kind
 of root-detection in this app. We need root to utilize Frida, so we got to figure out a way past this.
@@ -159,7 +159,7 @@ It's pretty clear that these three functions all perform different checks to
 make a guess if the phone is rooted. Since it doesn't seem like we _actually_ need these
 methods for the functionality of the app, lets overwrite them with Frida to all return `false`.
 
-<h2>Exploitation: Root Detection</h2>
+## Exploitation: Root Detection
 
 Have a look at the [Frida Java API](https://www.frida.re/docs/javascript-api/#java) before continuing. We will
 be using `Java.perform` to hook and modify the implementation of methods in the class above.
@@ -237,7 +237,7 @@ Android app - so cool!
 
 ![bypass-root](/assets/resources-frida-post/bypass-root.png)
 
-<h2>Investigation: Secret String</h2>
+## Investigation: Secret String
 
 We're in the app, but we still need the "secret string" to complete the challenge.  
 Digging around the app, there's a couple crypto classes imported into various files.
@@ -304,7 +304,7 @@ With frida we have the ability to call any function we'd like. Lets try to
 get the app to print the password for us, instead of feeding it into the variable in
 the function above.
 
-<h2>Exploitation: Secret String</h2>
+## Exploitation: Secret String
 
 Originally I started writing code to get me the values for the _arguments_ of `sg.vantagepoint.a.a.a()`.
 I was then going to call the method myself with those calculated values.
@@ -402,7 +402,7 @@ in the password `I want to believe`.
 
 ![correct-password](/assets/resources-frida-post/correct-password.png)
 
-<h2>Conclusion</h2>
+## Conclusion
 
 I hope this guide has helped illustrate the power of Frida. I definitely learned a ton
 by working through this problem.

--- a/src/content/blog/2018-07-10-iOS-push-notifications-react-native.md
+++ b/src/content/blog/2018-07-10-iOS-push-notifications-react-native.md
@@ -15,15 +15,15 @@ featured: true
 > This guide is the combination of the numerous resources found online into **one** place, as well as commentary from
 > me in places where things went wrong.
 
-<h2>Intro</h2>
-<h3>Goal</h3>
+## Intro
+### Goal
 We have been developing [Parade](https://parade.events/) for a few months now - and this morning I decided
 I wanted to implement push notifications - seems important for an events app, right?
 <br><br>
 In this guide we're going to be configuring our client to register with Apple's Push Notification Service (APN), register with
 *our* application server, and receive both local and remote notifications. We will be configuring our own application server to dispatch notifications to
 specific users of our service on command.
-<h3>What are we working with?</h3>
+### What are we working with?
 Parade is a React Native application that we've been writing and then deploying on TestFlight throughout development. We run
 our own node/graphQL server out on AWS that serves data to and from our app.
 <br><br>
@@ -35,7 +35,7 @@ bit of convenience is going to add up fast.
 Second, I was curious *how* to do it.  I now realize it was much more complicated than I expected...but if you're reading this, that
 means I got through it and (hopefully) condensed it down into simple(r) steps below.
 
-<h2>Prereqs</h2>
+## Prereqs
 - A Valid Apple Developer Account
 - A React Native (partially) written and deployable to TestFlight
 - A Mac (xcode)
@@ -46,13 +46,13 @@ need to tack on Android, so most of what I write in this guide has that eventual
 <br><br>
 If you're not using React Native/Redux/GraphQL/Mongo this guide may still be for you, just keep in mind that's the tech stack i'm working with.
 
-<h2>Local Notifications Client-side</h2>
+## Local Notifications Client-side
 
 Lets start slow and first focus on setting up local push notifications. These are notifications that are generated
 from the client itself, and not from a remote server. Doesn't seem too useful in the long run, but definitely a good
 place for us to start.
 
-<h3>Enable in Xcode</h3>
+### Enable in Xcode
 
 Enable the push notification capability for your project in XCode. For React Native, your
 `.xcodeproj` file can be found in the `ios/` folder of your project.
@@ -62,7 +62,7 @@ need it later - so lets just do it now.
 
 ![xcode-1](/assets/resources-push-notifications/xcode-1.png)
 
-<h3>react-native-push-notification</h3>
+### react-native-push-notification
 
 I'm going to be using a package called [react-native-push-notification](https://github.com/zo0r/react-native-push-notification),
 which wraps both the Android and iOS APIs that react-native provides. This package requires manual setup for both platform. For now,
@@ -72,14 +72,14 @@ To start, add the package to your react-native project with `yarn add react-nati
 <br><br>
 ...and link with `react-native link`.
 
-<h3>iOS Manual Install</h3>
+### iOS Manual Install
 
 I followed the official React Native docs to [link push notifications](https://facebook.github.io/react-native/docs/pushnotificationios.html). This involves opening up xcode and linking some react-native libraries. Follow this guide - it's very detailed, and very important!
 <br><br>
 [This page](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking) goes into detail of how to manually link libraries.
 I completed all three steps, and that seemed to work.
 
-<h3>Testing Local Notification</h3>
+### Testing Local Notification
 
 In my App's main file `App.js`, I then imported `react-native-push-notification` and
 wrote the following code in the `componentDidMount` lifecycle function.
@@ -103,7 +103,7 @@ requestPermissions: true, // This is the default value. We'll be modifying this 
 ```
 
 Next time I launched the app, I was prompted to allow push notifications - looking good!
-<br><br>
+
 ![allow-push-notifs](/assets/resources-push-notifications/allow-push-notifs.png)
 
 Lets now send a local notification. We'll trigger the notification via a button in the _secret_ Parade
@@ -130,7 +130,7 @@ I tied this function to a button...
 
 ![test-local-2](/assets/resources-push-notifications/test-local-2.png)
 
-<h2>Apple Developer Config</h2>
+## Apple Developer Config
 
 We will now visit the Apple dev site to mark our app as one that will be utilizing the Apple push notification (APN) service.
 <br><br>
@@ -162,7 +162,7 @@ Nice, now its green - and we have the cert saved to our Mac's keychain.
 
 ![keychain-access-1](/assets/resources-push-notifications/keychain-access-1.png)
 
-<h2>Requesting Token from APN in React Native</h2>
+## Requesting Token from APN in React Native
 
 Lets move back to our React Native project now. We have everything set up to receive
 push notification tokens from APN.
@@ -173,13 +173,13 @@ are registered.
 <br><br>
 I found this image from a post from user [Karan Alangat](https://stackoverflow.com/questions/17262511/how-do-ios-push-notifications-work)
 on stackOverflow that helped me understand the flow.
-<br><br>
+
 ![stackOverflow photo](https://i.stack.imgur.com/6HtsK.jpg)
 
 As you can see, requesting APN tokens are retrieved via a call to the OS itself. This is how push notifications are sent to a device without every
 single application on the device listening at the same time.
 
-<h3>Testing onRegister()</h3>
+### Testing onRegister()
 
 The `react-native-push-notification` API provides a function `onRegister()` that is called whenever our app registers with the APN servers. Lets see if we can get
 Apple to send us a token.
@@ -223,7 +223,7 @@ Each time I fully quit and launch the app I see this. Our app is now officially 
 
 ![push-registered](/assets/resources-push-notifications/push-registered.png)
 
-<h3>Storing tokens remotely</h3>
+### Storing tokens remotely
 
 This part of the article is going to start blurring the lines between client and server, and will
 also be very dependent on how your app is structured.
@@ -288,24 +288,24 @@ our goal was to get this value stored in a given user's database entry, like so.
 
 ![mongoEntry](/assets/resources-push-notifications/mongoEntry.png)
 
-<h2>Server setup</h2>
+## Server setup
 
 Great! We're now on to step 4 of the flow chart above. We have the iOS APN token saved on our server.
 We now need to determine when something interesting happens to our user and utilize that `iOSPushNotifToken` to tell Apple to issue a Push notification.
 
-<h3>Developer Notification Key</h3>
+### Developer Notification Key
 
 First things, first - another key! This one is issued by Apple, and is the key we need on our server to tell Apple we're authorized to send push notifications. Visit [this page](https://developer.apple.com/account/ios/authkey/) on the developer portal to create a key. You'll receive a `.p8` file and see your `Key ID` on screen. Keep both of these - we'll need them soon!
 
 ![create-key-1](/assets/resources-push-notifications/create-key-1.png)
 
-<h3>Yet another library</h3>
+### Yet another library
 This stuff is complicated, so we're going to utilize a library called [node-pushnotifications](https://github.com/appfeel/node-pushnotifications) to make our lives easier.
 This library issues push requests to the appropriate server (Apple, Google, etc...) for all the platforms (iOS, Android, etc...) we care about. This library even decides where to send the push to based on the device token you provide - that's pretty cool!
 <br><br>
 Get this running on your node server with `yarn add node-pushnotifications`.
 
-<h3>node-pushnotifications configuration</h3>
+### node-pushnotifications configuration
 
 Everything i'm going to do can be found in much greater detail over at [node-pushnotification's](https://github.com/appfeel/node-pushnotifications) README page.
 I'm going to walkthrough how to get a barebones notification dispatch system set up on your application's server, and only for iOS (for now).
@@ -425,9 +425,9 @@ So `http://localhost:port/testPush?msg=testing123` results in...
 
 ![more-remote-push](/assets/resources-push-notifications/more-remote-push.png)
 
-<h2>Other issues (and my fixes)</h2>
+## Other issues (and my fixes)
 
-<h3>Collisions</h3>
+### Collisions
 
 When Apple sends us an APN token, they don't know who is logged in, or even the concept of our app having users.
 Therefore, if two users login on the same device, they will be given the same token from Apple.
@@ -440,7 +440,7 @@ and we didn't clear the tokens from our database, so this happens.
 
 One solution is to clear the APN token from the user's identity on logout.
 
-<h3>TestFlight == Production (??)</h3>
+### TestFlight == Production (??)
 
 Small fix. When deploying to TestFlight, the `production` flag in our `node-pushnotifications` config must be set to `true`.
 Also make sure to securely copy your key over to your hosting server (don't check it into git!).
@@ -462,7 +462,7 @@ const push = new PushNotifications(settings);
 //{...truncated...}
 ```
 
-<h2>Final Words</h2>
+## Final Words
 Push notifications are not quite as simple as I imagined! There's lots of moving pieces...and the fact that we ignored
 Android the whole time definitely scares me... Now that it's set up, Parade definitely feels more complete!
 <br><br>

--- a/src/content/blog/2018-07-14-spotify-lambda-api.md
+++ b/src/content/blog/2018-07-14-spotify-lambda-api.md
@@ -17,19 +17,19 @@ exploring what my friends listen to. I've been really curious about uses for AWS
 Let's get started!
 <br><br>
 If you're curious what the finished product looks like, look up! My header should say something like:
-<br><br>
+
 ![example](/assets/resources-spotify-lambda-post/example.png)
 
-<h2>Overview</h2>
+## Overview
 In this guide we will be hosting a function on AWS Lambda, and using Spotify's web API to return a JSON object with the user's current or last played Spotify track. We will utilize Amazon's API Gateway to create a REST endpoint that can be used anywhere
 (I use it on my personal website) to serve dynamic content to static pages. I wrote the lambda function in python, but this should be easily adaptable to work with any language.
 
-<h2>Prereqs</h2>
+## Prereqs
 - AWS Account (Free Tier)
 - Spotify account (Premium)
 - Domain to point API at (Optional)
 
-<h2>Create Spotify Developer Account</h2>
+## Create Spotify Developer Account
 
 The first step is to visit the [Spotify developer dashboard][spotifydashboard] and create a new project. This process will grant you a
 Client ID and Client Secret. You'll need to base64 encode these two values with a colon separating them.
@@ -46,7 +46,7 @@ as long as you set one and it's consistent in all the following steps. I used `h
 
 ![spotify-callback](/assets/resources-spotify-lambda-post/spotify-callback.png)
 
-<h2>Generate Refresh Token</h2>
+## Generate Refresh Token
 
 Spotify's API requires direct user authorization to access information like current track.
 User resources can only be requested by _that_ user, so this means we need to be logged
@@ -95,7 +95,7 @@ def refreshTheToken(refreshToken):
 
 ```
 
-<h2>Start a new Lambda Project</h2>
+## Start a new Lambda Project
 
 Lambda, for those unfamiliar, is a compute platform that allows you to run code in the cloud without
 the hassle of configuring an entire server instance. Code can be running by hitting a REST endpoint.
@@ -105,7 +105,7 @@ python 2. Create a role that permits basic Amazon Lambda execution, as well as D
 
 ![create-function-photo](/assets/resources-spotify-lambda-post/create-lambda.png)
 
-<h2>Configuring Python Environment</h2>
+## Configuring Python Environment
 
 Before we can continue we need to upload all the dependencies of our project into lambda so we can use them later when we start writing code. Luckily the only
 dependency not pre-packaged in the lambda environment is an HTTP requests package.
@@ -127,7 +127,7 @@ Create a zip file, and upload this to your lambda function's dashboard. Now we c
 
 ![aws-editor](/assets/resources-spotify-lambda-post/aws-editor.png)
 
-<h2>DynamoDB</h2>
+## DynamoDB
 
 I ran into a problem where I wanted to have the ability to persist access tokens between API calls. Each access token is valid for an hour,
 so it felt like a waste to refresh the token on each API call. Lambda has integration with many of AWS's services, one of which is DynamoDB.
@@ -144,7 +144,7 @@ You can then link this table in the Lambda API console under `Add triggers => Dy
 
 ![dynamo-3](/assets/resources-spotify-lambda-post/dynamo-3.png)
 
-<h2>API Gateway</h2>
+## API Gateway
 
 Ok - one more piece of setup before we can begin writing our lambda function! We need a way to invoke our function from across the internet. AWS again offers
 a service called [API Gateway](https://us-east-2.console.aws.amazon.com/apigateway/home?region=us-east-2#/apis), which translates your lambda function into a REST API.
@@ -166,12 +166,12 @@ This next page is where you'll be given the option to point the API to your lamb
 It took me a while to understand why I need "Lambda Proxy" enabled. I found a lot of articles online outlining the pros and cons of using lambda proxy.
 For me, this setting made it easy for me to return json, and to return appropriate status codes from within my python function.
 
-<h2>Optional: Set up DNS</h2>
+## Optional: Set up DNS
 
 In API Gateway on the left you'll see "Custom Domain Names". I mapped my api to `https://api.joshspicer.com/` to make it easy to remember. Follow the instructions there
 of how to configure your own DNS.
 
-<h2>Lambda function</h2>
+## Lambda function
 
 We're now ready to fill out our lambda_function file!
 <br><br>
@@ -348,7 +348,7 @@ songName: "Everybody's Lonely"
 
 ```
 
-<h2>Client-side Javascript</h2>
+## Client-side Javascript
 
 You can use this information anyway you'd like. I wanted to utilize Lambda so that I could place dynamic
 content onto my static webpage hosted on Github Pages.
@@ -385,7 +385,7 @@ Place the following onto the page you'd like to display your "now playing" line.
 </p>
 ```
 
-<h2>All done!</h2>
+## All done!
 
 [spotifydashboard]: https://developer.spotify.com/dashboard/
 [lambda]: https://us-east-2.console.aws.amazon.com/lambda/home?region=us-east-2#/functions

--- a/src/content/blog/2018-08-02-parade-ios-universal-linking-test.md
+++ b/src/content/blog/2018-08-02-parade-ios-universal-linking-test.md
@@ -93,7 +93,7 @@ _handleOpenURL(evt) {
 }
 ```
 
-<h2>Test Links!</h2>
+## Test Links!
 
 Obviously none of these will work if you don't have Parade installed! These links are helping me test a few
 finer details (valid URLs but invalid IDs, etc...).

--- a/src/content/blog/2018-08-27-android-support-RN.md
+++ b/src/content/blog/2018-08-27-android-support-RN.md
@@ -10,17 +10,18 @@ tags:
 
 > Edit: Our Android release is out NOW on Google Play! Find it [here](https://play.google.com/store/apps/details?id=com.parade).
 
-<h2>Intro</h2>
+## Intro
 We focused on iOS for the initial development of Parade. Here are a small set of the things I learned had to be done differently when "porting" to Android.
 
 ![notebook](/assets/resources-android-support/notebook.png)
 
-<h2>Yoga Bug</h2>
+## Yoga Bug
 When prettier adds a stray semicolon automatically, iOS doesn't care but Android crashes..... I've seen this
 soo much.
+
 ![yoga_bug](/assets/resources-android-support/yoga-bug.png)
 
-<h2>Text Inputs look Ugly</h2>
+## Text Inputs look Ugly
 
 If you designed text inputs on iOS and are happy with them, you can make it look similar by adding `underlineColorAndroid`.
 ```javascript
@@ -35,7 +36,7 @@ underlineColorAndroid="transparent" <------- Add me!
 />
 ```
 
-<h2>Hardware Back Button</h2>
+## Hardware Back Button
 I love Android's "hardware" (it's on the screen of my pixel, but ya know what I mean) back button. iOS doesn't have this,
 so obviously it was not working as intended on Android. `React-navigation`'s docs said that it should work out of the box,
 but that didn't seem to be the case. Perhaps it's because we're utilizing 'modal' views (because of the animation).
@@ -58,10 +59,10 @@ handleBackPress = () => {
 }
 ```
 
-<h2>Fix Universal (HTTP) Linking</h2>
+## Fix Universal (HTTP) Linking
  Check out the dedicated post on it at [Android React Native Linking](/parade-linking-android).
 
- <h2>Software Keyboard Pushing Absolute Elements</h2>
+## Software Keyboard Pushing Absolute Elements
  On iOS elements styled with 'absolute' don't get pushed around - and we used that in our designs.
 
 ![keyboard-aware-before](/assets/resources-android-support/keyboard-aware-before.png)
@@ -72,11 +73,11 @@ I use react-native-keyboard-aware-scroll-view to do keyboard padding for us, sin
 
 ![keyboard-aware-after](/assets/resources-android-support/keyboard-aware-after.png)
 
-<h2>Manifest Updates</h2>
+## Manifest Updates
 
 I configured a lot of things in Xcode that I needed to re-do on Android.
 
-<h3>App Icons</h3>
+### App Icons
 I used [this site](https://romannurik.github.io/AndroidAssetStudio/icons-launcher.html) to create both
 rectangular and circular app icons. I then declared both in the manifest.
 ```xml
@@ -88,7 +89,7 @@ rectangular and circular app icons. I then declared both in the manifest.
   ...
   ...
 ```
-<h3>Device orientation</h3>
+### Device orientation
 Simple one. In my main MainActivity...
 ```xml
 <activity
@@ -102,7 +103,7 @@ Simple one. In my main MainActivity...
     ....
 ```
 
-<h2>Must meet API requirements for new apps</h2>
+## Must meet API requirements for new apps
 
 > Google Play will require that new apps target at least Android 8.0 (API level 26) from August 1, 2018...
 > Every new Android version introduces changes that bring significant security and performance improvements – and enhance the user experience of Android overall. > Some of these changes only apply to apps that explicitly declare support through their targetSdkVersion manifest attribute (also known as the target API level).
@@ -130,15 +131,15 @@ android {
         ...
 ```
 
-<h2>deployment RN docs</h2>
+## deployment RN docs
 Facebook has a really good guide on [creating your signed APK](https://facebook.github.io/react-native/docs/signed-apk-android.html), so i'll
 just add in pieces of info I found important on deployment.
 
-<h3>deployment keys on MacOS</h3>
+### deployment keys on MacOS
 I wasn't fond of keeping my app's cert password in plaintext, and neither was [Viktor Eriksson](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/
 ). If you're running macOS I suggest storing your passwords in the OSX keychain like he did.
 
-<h3>App Versioning</h3>
+### App Versioning
 In your app's `build.gradle` you need to specify two parameters before uploading to Google Play.
 ```java
 ...
@@ -160,7 +161,7 @@ android {
 
 ```
 
-<h3>Uploading APK</h3>
+### Uploading APK
 Once you release internally, it's going to say "Pending Publication" up top for a while. It's not explained well,
 but you just need to wait that out and then it will be available to your internal team. It took mine close to 30 minutes to
 actually publish.
@@ -171,7 +172,7 @@ Soooo many devices to deal with now.
 
 ![supported-devices](/assets/resources-android-support/supported-devices.png)
 
-<h3>Internal Testing</h3>
+### Internal Testing
 For some reason you need to add all your internal tester's emails on the web console, but then it doesn't
 automatically send out the invite link via email. After your app publishes, a new  `opt-in link` will be available on your release
 which you should manually email to all the people you added above (?).

--- a/src/content/blog/2018-11-05-hitch-to-paris.md
+++ b/src/content/blog/2018-11-05-hitch-to-paris.md
@@ -16,9 +16,9 @@ featured: true
 **Friday 9am**
 
 The race begins and it sets in that we had absolutely no plan. Do we head to Princes Street and try to beg for some cash? Do we head toward Waverley Station and try to get ourselves on **any** train heading south? We did none of those things - we just started walking. We ended up heading through Newington and generally south. We’d prepared our first whiteboard sign “Charity Hitch, Going South”, and started flashing it to passerbys and cars.
-<br><br>
+
 ![start](/assets/resources-hitch/start.jpeg)
-<br><br>
+
 Our sign attracted Brian, a uni employee that asked what we were up to! We explained, and he gave us some tips on the fastest route toward the motorway. We also got our first donation (~60p) from him!
 
 **Friday 10:30am**
@@ -28,13 +28,13 @@ Our walk took almost an hour and brought us to the Cameron Toll shopping center.
 Our first hitch was a younger woman on her morning ritual (getting coffee after dropping off her kid at school). She also was driving with a dog (which got us our first completed challenge!). Everyday she gets that coffee, and kept on telling me “I totally would’ve done this when I was in uni”.
 <br><br>
 She dropped us at a service station right off the A1, where (no surprise) there were several more teams trying to secure their next hitch as well!
-<br><br>
+
 ![first-hitch](/assets/resources-hitch/first-hitch.jpeg)
-<br><br>
+
 Our next hitch took a bit longer due to all the competition. Alek and I changed the sign to “A1 south” and approached every car we could filling up. A black VW eventually pulled in, and to my surprise I was the only hitcher to approach! I asked the man, and while he wasn’t going along the A1, he WAS going south. He went to pay for his gas and took a moment to “think about it”. When he returned, he agreed! Alek and I quickly hopped in before he changed his mind.
-<br><br>
+
 ![police](/assets/resources-hitch/police.jpeg)
-<br><br>
+
 This hitch was a New Zealand expat that was currently a regional salesman (he was traveling south for work). He originally moved to the UK for rugby, and agreed to drive us 50 miles!! This hitch brought us well over the Scottish border into England. He was a blast to talk with, and was the first to ask the question “soooo…what do you think of Trump?” (Awkward question to say the least, but our answers always seemed satisfactory to our drivers.) He brought us to a service station along the A1 in Berwick-upon-Tweed (TD15 2PD).
 
 **1pm**
@@ -46,9 +46,9 @@ After about 45 minutes of waving our sign outside the service station door we me
 This was perhaps our most interesting hitch! The son, named Leon Flint, turned out to be a semi-pro motocross racer. He races all over Europe (sometimes with crowds of 10,000 people!). His dad and him drive to all these races in this van we were passengers in, and have traveled thousands of miles together in it. Strapped in the back of the van was Leon’s motorcross bike, so the story seemed to check out.
 <br><br>
 We heard all about life on the road, crazy drunk nights that Leon’s dad spent in London, and also answered the Trump question again. We also learned about this crazy previous hitch of theirs where a man left a bag in the van (ask me about it). In the end, I left with the signed photo of Leon and a 2019 calendar of him racing. Totally hanging that up come January.
-<br><br>
+
 ![leon](/assets/resources-hitch/leon.jpeg)
-<br><br>
+
 We made a couple stops along the way (once for dinner - I got amazing Fish and Chips), and in the end were together for an amazing SIX HOURS!
 
 **7pm**

--- a/src/content/blog/2020-04-15-pi-contrHOLE.md
+++ b/src/content/blog/2020-04-15-pi-contrHOLE.md
@@ -20,5 +20,5 @@ redirectFrom:
 I've released the app on the iOS [App Store](https://apps.apple.com/us/app/pi-contrhole/id1507963158). If you have an iPhone or iPad, [**download the app for free!**](https://apps.apple.com/us/app/pi-contrhole/id1507963158)
 
 You can also choose to build the app yourself from [Github](https://github.com/joshspicer/pihole-mobile-app). Since it's Xamarin Forms, you can compile this app for Android as well!
-<br><br>
+
 ![1.png](/assets/resources-pihole/1.png)

--- a/src/content/blog/2024-12-31-sewing.md
+++ b/src/content/blog/2024-12-31-sewing.md
@@ -15,15 +15,13 @@ The ethos of this website is to express creativity and share topics I find gener
 
 Quilting is the process of adding these diagonal stitches across the surface. I used some chalk and a ruler to sketch guidelines, augmenting [this technique](https://hellocreativefamily.com/1-hour-diy-laptop-sleeve-sewing-tutorial-for-any-size-laptop/). I used batting, fabric, and thread from a thrift store. All the stitches are done flipped inside out with a given seam allowance. On my first try, I didn’t account for the "shrink" caused by the quilting, which coincidentally resulted in a nice fit for a 13" laptop.  
 
-![2.jpeg](/assets/resources-sewing/2.jpeg)  
-<div style="text-align: center; margin-bottom: 20px;"><small>A MacBook Pro 15" sleeve for my dad</small></div>  
+![A quilted rose-colored laptop sleeve with an embroidered dog portrait](/assets/resources-sewing/2.jpeg "A MacBook Pro 15-inch sleeve for my dad")
 
 For the machine embroidery, my technique was to first use the "remove background" feature of Pixelmator to isolate the important part of the image. I then exported the result as an SVG.  
 
 I imported the SVG using Inkscape with [Ink/Stitch](https://inkstitch.org/) installed. This Low Tech Linux [tutorial](https://www.youtube.com/watch?v=46kfuQWOPW0) on using Ink/Stitch is awesome. I found success by iteratively reducing the image down to three colors in mostly contiguous blocks. I used Ink/Stitch to export in the Brother-specific file format, which works perfectly with the [Brother SE700](https://www.brother-usa.com/products/se700).  
 
-![3.jpeg](/assets/resources-sewing/3.jpeg)  
-<div style="text-align: center; margin-bottom: 20px;"><small>A Kindle case for my mom</small></div>  
+![A plaid quilted tablet case with an embroidered cat portrait](/assets/resources-sewing/3.jpeg "A Kindle case for my mom")
 
 I 3D-printed the tray, which is handsewn into the back of the Kindle case. The bias tape around the case is handmade by folding a long strip in on itself from both sides into the middle of the strip. I used an iron to press the sides together, then wrapped that folded fabric along the outer edge to stitch it in place.  
 
@@ -39,5 +37,4 @@ The inside of each pouch uses the "opposite" fabric of its outside.
 
 My final exam was an elastic pencil case.  Follow [this](https://thefolkartfactory.com/super-easy-notebook-pencil-case-free-beginners-pattern) to try yourself.
 
-![pencil.gif](/assets/resources-sewing/pencil.gif)  
-<div style="text-align: center; margin-bottom: 20px;"><small>Bullet journal pencil case</small></div>
+![A slim quilted case strapped to a notebook, holding pens](/assets/resources-sewing/pencil.gif "Bullet journal pencil case")

--- a/src/content/blog/2025-02-15-bunny-bunch.md
+++ b/src/content/blog/2025-02-15-bunny-bunch.md
@@ -66,28 +66,15 @@ Win by collecting either:
 - 7 different types of bunnies
 - 2 types with at least 3 bunnies each
 
+![A bunny card moving from the hand into the grid of played cards](/assets/resources-bunny-bunch/2.gif "Playing a bunny and collecting cards")
 
-![2.gif](/assets/resources-bunny-bunch/2.gif)
-<div markdown="1" style="text-align: center; margin-bottom: 20px;"><small>Playing a bunny and collecting cards</small>
-</div>
+![Matching bunny cards being grouped together on the board](/assets/resources-bunny-bunch/3.gif "Forming a bunch")
 
-![3.gif](/assets/resources-bunny-bunch/3.gif)
-<div markdown="1" style="text-align: center; margin-bottom: 20px;"><small>Forming a bunch</small>
-</div>
+![A new card being drawn from the deck into the player's hand](/assets/resources-bunny-bunch/4.gif "Drawing from the deck")
 
-![4.gif](/assets/resources-bunny-bunch/4.gif)
-<div markdown="1" style="text-align: center; margin-bottom: 20px;"><small>Drawing from the deck</small>
-</div>
+![The main menu appearing over the board](/assets/resources-bunny-bunch/5.gif "Shake your phone (or press 'M' on a mac) to access the main menu")
 
-![5.gif](/assets/resources-bunny-bunch/5.gif)
-<div markdown="1" style="text-align: center; margin-bottom: 20px;"><small>Shake your phone (or press 'M' on a mac) to access the main menu</small>
-</div>
-
-
-![6.jpg](/assets/resources-bunny-bunch/6.jpg)
-<div markdown="1" style="text-align: center; margin-bottom: 20px;"><small>Play on your TV!</small>
-</div>
-
+![Bunny Bunch running on a living room television](/assets/resources-bunny-bunch/6.jpg "Play on your TV!")
 
 ### Multi-Device Play
 

--- a/src/content/blog/2025-05-24-habit-bridge.md
+++ b/src/content/blog/2025-05-24-habit-bridge.md
@@ -15,15 +15,8 @@ redirectFrom:
 
 Meet [**HabitBridge**](https://apps.apple.com/us/app/habitbridge/id6742713867) - a habit tracking app designed for developers, hackers, and anyone else who wants _real_ control over their digital habit tracking. 
 
-<div style="display: flex; justify-content: space-between; flex-wrap: wrap;">
-  <div style="flex: 1; min-width: 250px; padding-right: 10px;">
-    <img src="/assets/resources-habit-bridge/9.png" width="250">
-  </div>
-  <div style="flex: 1; min-width: 250px;">
-    <img src="/assets/resources-habit-bridge/2.png" width="250">
-  </div>
-</div>
-<br>
+![The HabitBridge home screen listing habits with daily check-off grids](/assets/resources-habit-bridge/9.png "Track habits day by day")
+![A plugin challenge asking the user to conjugate an Italian verb](/assets/resources-habit-bridge/2.png "…or gate a habit behind a custom plugin challenge")
 
 HabitBridge aims to be infinitely extensible to make habit tracking more effective and engaging. It combines "traditional" habit tracking features with a robust plugin framework and webhooks to trigger automations and integrate with any system you choose.
 
@@ -39,15 +32,8 @@ HabitBridge is available **for free** on the App Store:
 
 HabitBridge lets you set limits on distracting apps and only unlocks them after you've completed your daily habits. Want to check Instagram? Complete your morning workout first.
 
-<div style="display: flex; justify-content: space-between; flex-wrap: wrap;">
-  <div style="flex: 1; min-width: 250px; padding-right: 10px;">
-  <img src="/assets/resources-habit-bridge/12.png" alt="Screen Time permission screen showing HabitBridge requesting access to restrict app usage" width="250">
-  </div>
-  <div style="flex: 1; min-width: 250px;">
-    <img src="/assets/resources-habit-bridge/3.png" alt="" width="250">
-  </div>
-</div>
-<br>
+![Screen Time permission screen showing HabitBridge requesting access to restrict app usage](/assets/resources-habit-bridge/12.png "HabitBridge asks for Screen Time access")
+![Choosing which app categories to lock, such as Social and Games](/assets/resources-habit-bridge/3.png "Pick the categories to lock until habits are done")
 
 The app integrates directly with the iOS system Screen Time APIs.
 
@@ -55,15 +41,8 @@ The app integrates directly with the iOS system Screen Time APIs.
 
 HabitBridge makes it easy to manually track granular-based habits.
 
-<div style="display: flex; justify-content: space-between; flex-wrap: wrap;">
-  <div style="flex: 1; min-width: 250px; padding-right: 10px;">
-  <img src="/assets/resources-habit-bridge/10.png" width="250">
-  </div>
-  <div style="flex: 1; min-width: 250px;">
-    <img src="/assets/resources-habit-bridge/4.png" width="250">
-  </div>
-</div>
-<br>
+![The habit list showing a piano practice timer and a push-up counter](/assets/resources-habit-bridge/10.png "Timers and counters live alongside simple check-offs")
+![A habit detail screen showing 70% progress toward a 60 minute target](/assets/resources-habit-bridge/4.png "Each habit tracks progress toward its own target")
 
 
 ### Custom Plugin System
@@ -78,19 +57,12 @@ Want to share your creations? Submit your plugins to the [**HabitBridge repo on 
 
 Send your habit data to any system via webhooks, enabling powerful automations. Track your habits in spreadsheets, trigger smart home devices, or integrate with your existing productivity tools.
 
-<div style="display: flex; justify-content: space-between; flex-wrap: wrap;">
-  <div style="flex: 1; min-width: 250px; padding-right: 10px;">
-  <img src="/assets/resources-habit-bridge/16.png" alt="" width="250">
-  </div>
-  <div style="flex: 1; min-width: 250px;">
-    <img src="/assets/resources-habit-bridge/17.png" alt="" width="250">
-  </div>
-</div>
-<br>
+![HabitBridge settings with webhooks enabled and a local webhook URL](/assets/resources-habit-bridge/16.png "Point HabitBridge at any webhook URL")
+![A webhook log entry showing the JSON payload sent on habit completion](/assets/resources-habit-bridge/17.png "Every delivery is logged with its payload")
 
 This can be sent to any web service that accepts webhooks, allowing for endless integration possibilities. Every habit completion is logged with timestamps, making it easy to track your progress programmatically.
 
-<img src="/assets/resources-habit-bridge/15.png" alt="" width="700">
+![A terminal running an echo server printing the JSON payload HabitBridge posted](/assets/resources-habit-bridge/15.png)
 
 #### Home Assistant
 
@@ -111,9 +83,7 @@ After the first webhook is received, several new `habitbridge` prefixed sensors 
 
 Use these sensors to trigger automations based on habit completions.
 
-<img src="/assets/resources-habit-bridge/ha.gif" alt="" width="500">
-<div markdown="1" style="text-align: center; margin-bottom: 20px;"><small>Enables an LED strip when all habits are completed for the day</small>
-</div>
+![An LED strip switching on once the day's habits are complete](/assets/resources-habit-bridge/ha.gif "Enables an LED strip when all habits are completed for the day")
 
 Imagine your smart lights changing color when you complete your morning routine, or your coffee maker starting when you finish your workout.
 
@@ -122,7 +92,7 @@ Imagine your smart lights changing color when you complete your morning routine,
 
 See your habit completions at a glance with home screen widgets. More system integrations are planned and coming soon!
 
-<img src="/assets/resources-habit-bridge/7.png" width="400">
+![The HabitBridge home screen widget showing a completion grid](/assets/resources-habit-bridge/7.png "A home screen widget with the month's completions")
 
 ## Privacy & Data
 
@@ -216,15 +186,8 @@ app.init(() => {
 
 Need some more ideas? Check out the [Memory Sequence](https://github.com/joshspicer/HabitBridgeMarketplace/tree/main/memory-sequence) or [Meditation Timer](https://github.com/joshspicer/HabitBridgeMarketplace/tree/main/meditation-timer) plugin source code.
 
-<div style="display: flex; justify-content: space-between; flex-wrap: wrap;">
-  <div style="flex: 1; min-width: 250px; padding-right: 10px;">
-  <img src="/assets/resources-habit-bridge/18.gif" alt="" width="250">
-  </div>
-  <div style="flex: 1; min-width: 250px;">
-    <img src="/assets/resources-habit-bridge/19.gif" alt="" width="250">
-  </div>
-</div>
-<br>
+![The Memory Game plugin listed as a habit in HabitBridge](/assets/resources-habit-bridge/18.gif "Memory Sequence")
+![The Meditation Timer plugin listed as a habit in HabitBridge](/assets/resources-habit-bridge/19.gif "Meditation Timer")
 
 #### Publishing Your Plugin
 

--- a/src/content/blog/2025-07-31-mapcalipers.md
+++ b/src/content/blog/2025-07-31-mapcalipers.md
@@ -25,7 +25,7 @@ The iOS app helps you pinpoint your target's location within defined boundaries,
 
 This app is [free on the App Store](https://apps.apple.com/us/app/map-calipers/id6746725018)!
 
-<img src="/assets/resources-mapcalipers/cta.png" width="250" alt="Header photo of a full map">
+![MapCalipers showing a city-wide map covered in transit lines](/assets/resources-mapcalipers/cta.png)
 
 ## App Features
 
@@ -33,7 +33,7 @@ This app is [free on the App Store](https://apps.apple.com/us/app/map-calipers/i
 
 Start off by drawing the bounds of your play area. This can be a city, neighborhood, or any other defined space. The app will then display just transit that is within this area, allowing you to focus on the most relevant routes and stops.
 
-<img src="/assets/resources-mapcalipers/setup.png" width="250" alt="Setup">
+![Setting up the play area by tapping points on the map](/assets/resources-mapcalipers/setup.png "Drop points to trace the play area before the game starts")
 
 
 ### Tools
@@ -42,38 +42,35 @@ The app provides a suite of tools to help you analyze the map and your target's 
 
 Use the **Radar Tool** to quickly drop a circle and ask if the target is inside or outside. The app creates an exclusion zone based on your answer.
 
-<img src="/assets/resources-mapcalipers/radar.png" width="250" alt="Radar tool screenshot">
-
 Use the **Thermometer Tool** to pick two points and see which side of the line the target is on. Great for slicing the map in half.
 
-<img src="/assets/resources-mapcalipers/thermometer.png" width="250" alt="Thermometer tool screenshot">
-
-
 Feel creative? Use the **Custom Polygon** tool to rule out complex shapes. Perfect for excluding irregular areas.
-
-<img src="/assets/resources-mapcalipers/custom.png" width="250" alt="Custom polygon screenshot">
 
 Use the **Distance Tool** to measure the straight-line distance between two points on the map.
 
 Use the **Measure Tool** to measure distances along a path with multiple waypoints.
 
+![The radar tool asking whether the target is inside or outside a circle](/assets/resources-mapcalipers/radar.png "Radar: rule out everything inside or outside the circle")
+![The thermometer tool splitting the map along a line](/assets/resources-mapcalipers/thermometer.png "Thermometer: slice the play area in half")
+![The custom polygon tool excluding an irregular shape](/assets/resources-mapcalipers/custom.png "Custom polygon: exclude any shape you draw")
+
 ### Inspect Transit
 
 Analyze nearby bus and train routes or stops that are still within the viable search area. 
 
-<img src="/assets/resources-mapcalipers/inspect.png" width="250" alt="Inspect tool screenshot">
+![A list of bus routes and stops inside the viable search area](/assets/resources-mapcalipers/inspect.png "Only the routes and stops still in play are listed")
 
 ### Sync
 
 Share your game state with friends or collaborate on a shared map. The app allows you to push and pull game state to/from a collaboration server using a secret passphase.
 
-<img src="/assets/resources-mapcalipers/sync.png" width="250" alt="Syncing">
+![The sync settings screen with a server address and passphrase](/assets/resources-mapcalipers/sync.png "Push and pull game state with a shared passphrase")
 
 ### Timeline History
 
 Every tool use is recorded in the timeline. Jump back to previous steps to fix any mistakes.
 
-<img src="/assets/resources-mapcalipers/timeline.png" width="250" alt="Timeline history screenshot">
+![The timeline listing each tool used during a game](/assets/resources-mapcalipers/timeline.png "Jump back to any earlier step to undo a mistake")
 
 
 ## Self-hosting

--- a/src/content/blog/2026-01-24-tankgame.md
+++ b/src/content/blog/2026-01-24-tankgame.md
@@ -29,10 +29,8 @@ When I was younger and got my first iPod Touch, I loved the (no longer available
 
 Navigate procedurally generated maps, dodge incoming fire, and be the last tank standing. Maps come in different sizes — from compact 6x6 arenas to sprawling 12x12 battlefields.
 
-<div style="display: flex; justify-content: center; gap: 10px; flex-wrap: wrap;">
-  <img src="/assets/resources-tankgame/6x6.png" style="width: 45%; max-width: 300px;" alt="6x6 Map"/>
-  <img src="/assets/resources-tankgame/12x12.png" style="width: 45%; max-width: 300px;" alt="12x12 Map"/>
-</div>
+![A compact 6x6 map](/assets/resources-tankgame/6x6.png "A compact 6x6 arena")
+![A sprawling 12x12 map](/assets/resources-tankgame/12x12.png "A sprawling 12x12 battlefield")
 
 ## Privacy
 

--- a/src/integrations/responsiveImages.mjs
+++ b/src/integrations/responsiveImages.mjs
@@ -1,0 +1,298 @@
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { dirname, extname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const IMG_TAG = /<img\b[^>]*>/gi;
+const ATTRIBUTE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g;
+const OPTIMIZABLE = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif']);
+const WIDTH_LADDER = [320, 480, 640, 960, 1280, 1920];
+// Beyond this, extra pixels only pad the download; the lightbox never shows
+// more than ~1400 CSS pixels wide.
+const MAX_WIDTH = 1920;
+// Small files cost more in requests than they save in bytes.
+const MIN_SOURCE_BYTES = 24_000;
+// Widest the prose column ever renders, in CSS pixels.
+const COLUMN_WIDTH = 608;
+const CONCURRENCY = 6;
+
+const parseAttributes = (tag) => {
+  const properties = {};
+  const inner = tag.replace(/^<img\b/i, '').replace(/\/?>$/, '');
+  ATTRIBUTE.lastIndex = 0;
+
+  let match = ATTRIBUTE.exec(inner);
+  while (match) {
+    const [, name, doubleQuoted, singleQuoted] = match;
+    properties[name] = doubleQuoted ?? singleQuoted ?? '';
+    match = ATTRIBUTE.exec(inner);
+  }
+
+  return properties;
+};
+
+const listHtmlFiles = async (directory) => {
+  const files = [];
+  const walk = async (current) => {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const path = join(current, entry.name);
+      if (entry.isDirectory()) await walk(path);
+      else if (entry.name.endsWith('.html')) files.push(path);
+    }
+  };
+  await walk(directory);
+  return files;
+};
+
+/**
+ * Estimates the widest CSS size an image is displayed at, mirroring the figure
+ * rules in the stylesheet, so `sizes` doesn't ask for more pixels than the
+ * layout can ever use.
+ */
+const displayWidthOf = ({ width, height, inGallery }) => {
+  const ratio = width / height;
+  const isLandscape = ratio >= 1 / 0.85;
+  const heightCap = inGallery ? 384 : 480; // 24rem / 30rem
+  const columnCap = inGallery ? COLUMN_WIDTH / 2 : COLUMN_WIDTH;
+
+  return Math.min(
+    width,
+    columnCap,
+    isLandscape ? Number.POSITIVE_INFINITY : Math.round(heightCap * ratio),
+  );
+};
+
+const toUrl = (output, outputDirectory, base) =>
+  `${base.replace(/\/$/, '')}/${relative(outputDirectory, output)
+    .split(/[\\/]/)
+    .map(encodeURIComponent)
+    .join('/')}`;
+
+/**
+ * Encoding every variant on each build is slow, and the build output is wiped
+ * between runs, so finished variants are kept in a cache keyed by the source
+ * file's identity plus the encode settings.
+ */
+const createVariantCache = (cacheDirectory) => {
+  let ready;
+
+  return async (key, output, encode) => {
+    ready ??= mkdir(cacheDirectory, { recursive: true });
+    await ready;
+
+    const cached = join(cacheDirectory, `${createHash('sha1').update(key).digest('hex')}.webp`);
+    await mkdir(dirname(output), { recursive: true });
+
+    try {
+      await copyFile(cached, output);
+      return (await stat(output)).size;
+    } catch {
+      const buffer = await encode();
+      await writeFile(output, buffer);
+      await writeFile(cached, buffer).catch(() => {});
+      return buffer.length;
+    }
+  };
+};
+
+const runPool = async (items, worker) => {  const queue = [...items];
+  const runners = Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+    let item = queue.shift();
+    while (item) {
+      await worker(item);
+      item = queue.shift();
+    }
+  });
+  await Promise.all(runners);
+};
+
+/**
+ * Rewrites built `<img>` tags into `<picture>` elements backed by resized WebP
+ * variants. Astro's asset pipeline only handles images imported from `src/`,
+ * and this site keeps its images in `public/`, so the work happens on the
+ * finished HTML instead. Original files stay in place as the fallback.
+ */
+export function responsiveImages() {
+  let base = '/';
+
+  return {
+    name: 'responsive-images',
+    hooks: {
+      'astro:config:done': ({ config }) => {
+        base = config.base ?? '/';
+      },
+      'astro:build:done': async ({ dir, logger }) => {
+        const { default: sharp } = await import('sharp');
+        const outputDirectory = fileURLToPath(dir);
+        const cacheVariant = createVariantCache(
+          fileURLToPath(new URL('../../node_modules/.cache/responsive-images/', import.meta.url)),
+        );
+        const htmlFiles = await listHtmlFiles(outputDirectory);
+
+        const sources = new Map();
+        const rewrites = [];
+
+        for (const file of htmlFiles) {
+          const html = await readFile(file, 'utf8');
+          IMG_TAG.lastIndex = 0;
+          const tags = html.match(IMG_TAG);
+          if (!tags) continue;
+
+          for (const tag of tags) {
+            const attributes = parseAttributes(tag);
+            const src = attributes.src;
+            if (!src?.startsWith('/') || src.startsWith('//')) continue;
+            if (!OPTIMIZABLE.has(extname(src).toLowerCase())) continue;
+
+            const withoutBase =
+              base !== '/' && src.startsWith(base) ? src.slice(base.length - 1) : src;
+            const filePath = join(outputDirectory, decodeURI(withoutBase));
+            if (!sources.has(filePath)) sources.set(filePath, src);
+            rewrites.push({ file, tag, attributes, filePath });
+          }
+        }
+
+        if (rewrites.length === 0) return;
+
+        const variants = new Map();
+        let originalBytes = 0;
+        let variantBytes = 0;
+
+        await runPool([...sources.keys()], async (filePath) => {
+          let image;
+          let metadata;
+          try {
+            image = sharp(filePath);
+            metadata = await image.metadata();
+          } catch {
+            return; // Referenced file isn't on disk; leave the tag alone.
+          }
+          if (!metadata.width || !metadata.height) return;
+
+          const sourceBytes = (await stat(filePath)).size;
+          if (sourceBytes < MIN_SOURCE_BYTES) return;
+          originalBytes += sourceBytes;
+
+          const animated = (metadata.pages ?? 1) > 1;
+          const height = animated ? (metadata.pageHeight ?? metadata.height) : metadata.height;
+          const generated = [];
+          const identity = `${relative(outputDirectory, filePath)}:${sourceBytes}:${metadata.width}x${height}`;
+
+          if (animated) {
+            // One frame-preserving variant: an animation ladder would multiply
+            // encoding cost for sizes no layout asks for.
+            const target = Math.min(
+              metadata.width,
+              Math.max(480, Math.round(displayWidthOf({
+                width: metadata.width,
+                height,
+                inGallery: false,
+              }) * 1.5)),
+            );
+            const output = filePath.replace(/\.[^.]+$/, `-${target}.webp`);
+            const bytes = await cacheVariant(
+              `${identity}:animated:${target}:q70`,
+              output,
+              () =>
+                sharp(filePath, { animated: true })
+                  .resize({ width: target, withoutEnlargement: true })
+                  .webp({ quality: 70, effort: 4 })
+                  .toBuffer(),
+            );
+            variantBytes += bytes;
+            generated.push({ width: target, url: toUrl(output, outputDirectory, base) });
+          } else {
+            const ceiling = Math.min(metadata.width, MAX_WIDTH);
+            const widths = WIDTH_LADDER.filter((width) => width < ceiling);
+            widths.push(ceiling);
+
+            for (const width of widths) {
+              const output = filePath.replace(/\.[^.]+$/, `-${width}.webp`);
+              const bytes = await cacheVariant(
+                `${identity}:${width}:q78`,
+                output,
+                () =>
+                  sharp(filePath)
+                    .resize({ width, withoutEnlargement: true })
+                    .webp({ quality: 78 })
+                    .toBuffer(),
+              );
+              variantBytes += bytes;
+              generated.push({ width, url: toUrl(output, outputDirectory, base) });
+            }
+          }
+
+          variants.set(filePath, {
+            width: metadata.width,
+            height,
+            animated,
+            generated,
+          });
+        });
+
+        const byFile = new Map();
+        for (const rewrite of rewrites) {
+          const list = byFile.get(rewrite.file) ?? [];
+          list.push(rewrite);
+          byFile.set(rewrite.file, list);
+        }
+
+        for (const [file, list] of byFile) {
+          let html = await readFile(file, 'utf8');
+
+          for (const { tag, attributes, filePath } of list) {
+            const variant = variants.get(filePath);
+            if (!variant || variant.generated.length === 0) continue;
+
+            const inGallery = html.includes('prose-gallery') && isInGallery(html, tag);
+            const displayWidth = displayWidthOf({ ...variant, inGallery });
+            const largest = variant.generated.at(-1).url;
+
+            let sourceAttributes;
+            let extraImageAttributes = '';
+            if (variant.animated) {
+              sourceAttributes = `srcset="${largest}"`;
+            } else {
+              const sizes = `(max-width: 40rem) ${inGallery ? '46vw' : '92vw'}, ${Math.round(displayWidth)}px`;
+              const srcset = variant.generated
+                .map(({ url, width }) => `${url} ${width}w`)
+                .join(', ');
+              sourceAttributes = `srcset="${srcset}" sizes="${sizes}"`;
+              extraImageAttributes = ` sizes="${sizes}"`;
+            }
+
+            // The viewer should open the optimized variant, not the original.
+            if (!attributes['data-zoom-src']) {
+              extraImageAttributes += ` data-zoom-src="${largest}"`;
+            }
+
+            const image = `${tag.replace(/\/?>$/, '')}${extraImageAttributes}>`;
+            const picture =
+              `<picture><source type="image/webp" ${sourceAttributes}>${image}</picture>`;
+
+            html = html.replace(tag, picture);
+          }
+
+          await writeFile(file, html);
+        }
+
+        const saved = originalBytes - variantBytes;
+        logger.info(
+          `optimized ${variants.size} images: ${(originalBytes / 1e6).toFixed(1)}MB of originals ` +
+            `→ ${(variantBytes / 1e6).toFixed(1)}MB of WebP variants ` +
+            `(${saved > 0 ? Math.round((saved / originalBytes) * 100) : 0}% smaller, originals kept as fallback)`,
+        );
+      },
+    },
+  };
+}
+
+/** Cheap containment test: is this tag inside a gallery wrapper? */
+const isInGallery = (html, tag) => {
+  const index = html.indexOf(tag);
+  if (index === -1) return false;
+  const galleryStart = html.lastIndexOf('<div class="prose-gallery"', index);
+  if (galleryStart === -1) return false;
+  const galleryEnd = html.indexOf('</div>', galleryStart);
+  return galleryEnd === -1 || galleryEnd > index;
+};

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -104,9 +104,13 @@ const repositoryEditorUrl = getRepositoryEditorUrl(repositoryPath);
     </script>
     <script>
       import { initHighlightAnimations } from '../scripts/highlightAnimations';
+      import { initHeadingAnchors } from '../scripts/headingAnchors';
+      import { initImageLightbox } from '../scripts/imageLightbox';
       import { initRepositoryShortcut } from '../scripts/repositoryShortcut';
 
       initHighlightAnimations();
+      initHeadingAnchors();
+      initImageLightbox();
       const repositoryEditorMeta = document.querySelector(
         'meta[name="repository-editor-url"]',
       );

--- a/src/plugins/imageSize.mjs
+++ b/src/plugins/imageSize.mjs
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs';
+
+const cache = new Map();
+
+const readPng = (buffer) => {
+  if (buffer.length < 24) return undefined;
+  if (buffer.readUInt32BE(0) !== 0x89504e47) return undefined;
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+};
+
+const readGif = (buffer) => {
+  if (buffer.length < 10) return undefined;
+  if (buffer.toString('ascii', 0, 3) !== 'GIF') return undefined;
+  return { width: buffer.readUInt16LE(6), height: buffer.readUInt16LE(8) };
+};
+
+const SOF_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+]);
+
+const EXIF_ORIENTATION_TAG = 0x0112;
+
+/** Reads the EXIF orientation out of an APP1 segment, if it declares one. */
+const readExifOrientation = (buffer, start, length) => {
+  if (buffer.toString('ascii', start, start + 6) !== 'Exif\0\0') return undefined;
+
+  const tiff = start + 6;
+  const byteOrder = buffer.toString('ascii', tiff, tiff + 2);
+  const littleEndian = byteOrder === 'II';
+  if (!littleEndian && byteOrder !== 'MM') return undefined;
+
+  const readShort = (at) =>
+    littleEndian ? buffer.readUInt16LE(at) : buffer.readUInt16BE(at);
+  const readLong = (at) =>
+    littleEndian ? buffer.readUInt32LE(at) : buffer.readUInt32BE(at);
+
+  const directory = tiff + readLong(tiff + 4);
+  const end = start + length;
+  if (directory + 2 > end) return undefined;
+
+  const entries = readShort(directory);
+  for (let index = 0; index < entries; index += 1) {
+    const entry = directory + 2 + index * 12;
+    if (entry + 12 > end) break;
+    if (readShort(entry) === EXIF_ORIENTATION_TAG) return readShort(entry + 8);
+  }
+
+  return undefined;
+};
+
+const readJpeg = (buffer) => {
+  if (buffer.length < 4 || buffer.readUInt16BE(0) !== 0xffd8) return undefined;
+
+  let offset = 2;
+  let orientation;
+  while (offset + 9 < buffer.length) {
+    if (buffer[offset] !== 0xff) {
+      offset += 1;
+      continue;
+    }
+
+    const marker = buffer[offset + 1];
+    if (SOF_MARKERS.has(marker)) {
+      const width = buffer.readUInt16BE(offset + 7);
+      const height = buffer.readUInt16BE(offset + 5);
+      // Orientations 5-8 rotate by a quarter turn, so the rendered size is
+      // transposed relative to the stored size.
+      return orientation && orientation >= 5 && orientation <= 8
+        ? { width: height, height: width }
+        : { width, height };
+    }
+
+    const segmentLength = buffer.readUInt16BE(offset + 2);
+    if (segmentLength < 2) return undefined;
+    if (marker === 0xe1) {
+      orientation ??= readExifOrientation(buffer, offset + 4, segmentLength - 2);
+    }
+    offset += 2 + segmentLength;
+  }
+
+  return undefined;
+};
+
+const readWebp = (buffer) => {
+  if (buffer.length < 30) return undefined;
+  if (buffer.toString('ascii', 0, 4) !== 'RIFF') return undefined;
+  if (buffer.toString('ascii', 8, 12) !== 'WEBP') return undefined;
+
+  const format = buffer.toString('ascii', 12, 16);
+  if (format === 'VP8 ') {
+    return {
+      width: buffer.readUInt16LE(26) & 0x3fff,
+      height: buffer.readUInt16LE(28) & 0x3fff,
+    };
+  }
+  if (format === 'VP8L') {
+    const bits = buffer.readUInt32LE(21);
+    return {
+      width: (bits & 0x3fff) + 1,
+      height: ((bits >>> 14) & 0x3fff) + 1,
+    };
+  }
+  if (format === 'VP8X') {
+    return {
+      width: buffer.readUIntLE(24, 3) + 1,
+      height: buffer.readUIntLE(27, 3) + 1,
+    };
+  }
+
+  return undefined;
+};
+
+const readSvg = (buffer) => {
+  const markup = buffer.toString('utf8', 0, 2048);
+  const viewBox =
+    /viewBox\s*=\s*["']\s*[\d.+-]+[,\s]+[\d.+-]+[,\s]+([\d.]+)[,\s]+([\d.]+)/i.exec(
+      markup,
+    );
+  if (viewBox) {
+    return { width: Number(viewBox[1]), height: Number(viewBox[2]) };
+  }
+
+  const width = /\bwidth\s*=\s*["']([\d.]+)/i.exec(markup);
+  const height = /\bheight\s*=\s*["']([\d.]+)/i.exec(markup);
+  if (width && height) {
+    return { width: Number(width[1]), height: Number(height[1]) };
+  }
+
+  return undefined;
+};
+
+const readers = [readPng, readGif, readJpeg, readWebp, readSvg];
+
+/**
+ * Reads the intrinsic pixel size of an image without pulling in a dependency.
+ * Supported formats cover everything the site ships: PNG, JPEG, GIF, WebP, SVG.
+ */
+export function getImageSize(filePath) {
+  if (cache.has(filePath)) {
+    return cache.get(filePath);
+  }
+
+  let size;
+  try {
+    const buffer = readFileSync(filePath);
+    for (const reader of readers) {
+      const result = reader(buffer);
+      if (result?.width && result?.height) {
+        size = { width: Math.round(result.width), height: Math.round(result.height) };
+        break;
+      }
+    }
+  } catch {
+    size = undefined;
+  }
+
+  cache.set(filePath, size);
+  return size;
+}

--- a/src/plugins/proseMedia.mjs
+++ b/src/plugins/proseMedia.mjs
@@ -1,0 +1,390 @@
+import { fileURLToPath } from 'node:url';
+import { getImageSize } from './imageSize.mjs';
+
+const IMAGE_INDEX_KEY = '__proseMediaImageIndex';
+const PORTRAIT_RATIO = 1.2;
+const LANDSCAPE_RATIO = 0.85;
+const IMG_TAG = /<img\b[^>]*>/gi;
+const ATTRIBUTE =
+  /([a-zA-Z_:][-a-zA-Z0-9_:.]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+// Elements that only accept phrasing content, where a <figure> would break out
+// of its parent when the browser parses the markup.
+const PHRASING_CONTAINERS = new Set([
+  'p',
+  'a',
+  'span',
+  'em',
+  'strong',
+  'b',
+  'i',
+  's',
+  'u',
+  'small',
+  'sub',
+  'sup',
+  'code',
+  'label',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'figcaption',
+  'dt',
+]);
+
+const isWhitespaceText = (child) =>
+  child.type === 'text' && child.value.trim() === '';
+
+const isImageElement = (child) =>
+  child.type === 'element' && child.tagName === 'img';
+
+const isLinkedImage = (child) =>
+  child.type === 'element' &&
+  child.tagName === 'a' &&
+  child.children.filter((grandChild) => !isWhitespaceText(grandChild)).every(isImageElement);
+
+const escapeAttribute = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+const escapeText = (value) =>
+  String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const toPositiveNumber = (value) => {
+  const parsed = Number.parseFloat(String(value ?? ''));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+const orientationOf = (width, height) => {
+  const ratio = height / width;
+  if (ratio >= PORTRAIT_RATIO) return 'portrait';
+  if (ratio <= LANDSCAPE_RATIO) return 'landscape';
+  return 'square';
+};
+
+const nextImageIndex = (ctx) => {
+  const index = ctx.data[IMAGE_INDEX_KEY] ?? 0;
+  ctx.data[IMAGE_INDEX_KEY] = index + 1;
+  return index;
+};
+
+const resolveIntrinsicSize = (src, publicDir) => {
+  if (typeof src !== 'string' || !src.startsWith('/') || src.startsWith('//')) {
+    return undefined;
+  }
+
+  const [pathname] = src.split(/[?#]/);
+  let decoded = pathname;
+  try {
+    decoded = decodeURI(pathname);
+  } catch {
+    // Keep the raw pathname when it isn't valid percent-encoding.
+  }
+
+  return getImageSize(fileURLToPath(new URL(`.${decoded}`, publicDir)));
+};
+
+/**
+ * Normalizes an image's attributes: intrinsic dimensions (so the browser can
+ * reserve space before the file loads), lazy loading for everything below the
+ * fold, and an orientation hint the stylesheet uses for layout.
+ */
+const enhanceImageProperties = (properties, ctx, publicDir) => {
+  const next = { ...properties };
+  const index = nextImageIndex(ctx);
+  const intrinsic = resolveIntrinsicSize(next.src, publicDir);
+  const declaredWidth = toPositiveNumber(next.width);
+  const declaredHeight = toPositiveNumber(next.height);
+
+  if (intrinsic && !(declaredWidth && declaredHeight)) {
+    if (declaredWidth) {
+      next.height = Math.round((declaredWidth * intrinsic.height) / intrinsic.width);
+    } else if (declaredHeight) {
+      next.width = Math.round((declaredHeight * intrinsic.width) / intrinsic.height);
+    } else {
+      next.width = intrinsic.width;
+      next.height = intrinsic.height;
+    }
+  }
+
+  const width = toPositiveNumber(next.width) ?? intrinsic?.width;
+  const height = toPositiveNumber(next.height) ?? intrinsic?.height;
+  if (width && height) {
+    next['data-orientation'] = orientationOf(width, height);
+  }
+
+  if (!next.loading) {
+    // The first image is the likely LCP element, so it should never be deferred.
+    next.loading = index === 0 ? 'eager' : 'lazy';
+  }
+  if (!next.decoding) {
+    next.decoding = index === 0 ? 'sync' : 'async';
+  }
+  if (index === 0 && !next.fetchpriority) {
+    next.fetchpriority = 'high';
+  }
+  if (next.alt === undefined || next.alt === null) {
+    next.alt = '';
+  }
+
+  return next;
+};
+
+const captionOf = (properties) => {
+  const caption = properties['data-caption'] ?? properties.title;
+  return typeof caption === 'string' && caption.trim() ? caption.trim() : undefined;
+};
+
+const withoutCaptionProperties = (properties) => {
+  const { title, 'data-caption': _dataCaption, ...rest } = properties;
+  return rest;
+};
+
+const element = (tagName, properties, children = []) => ({
+  type: 'element',
+  tagName,
+  properties,
+  children,
+});
+
+const buildFigure = (properties, linkProperties) => {
+  const caption = captionOf(properties);
+  const imageProperties = caption ? withoutCaptionProperties(properties) : properties;
+  const image = element('img', imageProperties, []);
+  const content = linkProperties ? element('a', linkProperties, [image]) : image;
+
+  const children = [content];
+  if (caption) {
+    children.push(
+      element('figcaption', { className: ['prose-caption'] }, [
+        { type: 'text', value: caption },
+      ]),
+    );
+  }
+
+  const figureProperties = { className: ['prose-figure'] };
+  if (properties['data-orientation']) {
+    figureProperties['data-orientation'] = properties['data-orientation'];
+  }
+  if (linkProperties) {
+    figureProperties['data-linked'] = 'true';
+  }
+
+  return element('figure', figureProperties, children);
+};
+
+const buildImageHtml = (properties) => {
+  const imageProperties = captionOf(properties)
+    ? withoutCaptionProperties(properties)
+    : properties;
+  const attributes = Object.entries(imageProperties)
+    .filter(([, value]) => value !== undefined && value !== null && value !== false)
+    .map(([key, value]) =>
+      value === true ? key : `${key}="${escapeAttribute(value)}"`,
+    )
+    .join(' ');
+
+  return `<img ${attributes}>`;
+};
+
+const buildFigureHtml = (properties) => {
+  const caption = captionOf(properties);
+  const orientation = properties['data-orientation'];
+  const figureAttributes = [
+    'class="prose-figure"',
+    orientation ? `data-orientation="${orientation}"` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const figcaption = caption
+    ? `<figcaption class="prose-caption">${escapeText(caption)}</figcaption>`
+    : '';
+
+  return `<figure ${figureAttributes}>${buildImageHtml(properties)}${figcaption}</figure>`;
+};
+
+const NAMED_ENTITIES = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: '\u00a0',
+};
+
+const decodeEntities = (value) =>
+  value.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, reference) => {
+    if (reference.startsWith('#x') || reference.startsWith('#X')) {
+      return String.fromCodePoint(Number.parseInt(reference.slice(2), 16));
+    }
+    if (reference.startsWith('#')) {
+      return String.fromCodePoint(Number.parseInt(reference.slice(1), 10));
+    }
+    return NAMED_ENTITIES[reference.toLowerCase()] ?? match;
+  });
+
+const parseImageAttributes = (tag) => {
+  const inner = tag.replace(/^<img\b/i, '').replace(/\/?>$/, '');
+  const properties = {};
+  ATTRIBUTE.lastIndex = 0;
+
+  let match = ATTRIBUTE.exec(inner);
+  while (match) {
+    const [, name, doubleQuoted, singleQuoted, unquoted] = match;
+    const value = doubleQuoted ?? singleQuoted ?? unquoted;
+    // Values arrive still encoded; they are re-escaped when serialized back out.
+    properties[name] = value === undefined ? true : decodeEntities(value);
+    match = ATTRIBUTE.exec(inner);
+  }
+
+  return properties;
+};
+
+/**
+ * Collects the images of a paragraph that contains nothing but images, which is
+ * how Markdown renders a standalone image (or a row of them).
+ */
+const collectStandaloneImages = (node) => {
+  const meaningful = node.children.filter((child) => !isWhitespaceText(child));
+  if (meaningful.length === 0) return undefined;
+
+  const images = [];
+  for (const child of meaningful) {
+    if (isImageElement(child)) {
+      images.push({ properties: child.properties ?? {} });
+      continue;
+    }
+    if (isLinkedImage(child)) {
+      const image = child.children.find(isImageElement);
+      if (!image) return undefined;
+      images.push({
+        properties: image.properties ?? {},
+        linkProperties: child.properties ?? {},
+      });
+      continue;
+    }
+    if (child.type === 'element' && child.tagName === 'br') continue;
+    return undefined;
+  }
+
+  return images.length > 0 ? images : undefined;
+};
+
+/** Paragraphs are the only container the paragraph visitor rebuilds. */
+const isStandaloneImageParagraph = (node) =>
+  node?.type === 'element' &&
+  node.tagName === 'p' &&
+  Boolean(collectStandaloneImages(node));
+
+const buildMediaBlock = (images, ctx, publicDir, toFigure) => {
+  const figures = images.map(({ properties, linkProperties }) =>
+    toFigure(enhanceImageProperties(properties, ctx, publicDir), linkProperties),
+  );
+
+  return { figures, isGallery: figures.length > 1 };
+};
+
+/**
+ * Markdown/HTML post-processing that turns bare images into accessible,
+ * layout-stable figures, groups adjacent images into a responsive gallery, and
+ * promotes image titles to visible captions.
+ */
+export function proseMedia({ publicDir = new URL('../../public/', import.meta.url) } = {}) {
+  const publicDirUrl =
+    typeof publicDir === 'string' ? new URL(`file://${publicDir}`) : publicDir;
+  // Touch the path once so a bad value fails at config time, not mid-build.
+  fileURLToPath(publicDirUrl);
+
+  return {
+    name: 'prose-media',
+    element: [
+      {
+        filter: ['p'],
+        visit(node, ctx) {
+          const images = collectStandaloneImages(node);
+          if (!images) return;
+
+          const { figures, isGallery } = buildMediaBlock(
+            images,
+            ctx,
+            publicDirUrl,
+            buildFigure,
+          );
+
+          if (!isGallery) return figures[0];
+
+          return element(
+            'div',
+            { className: ['prose-gallery'], 'data-count': figures.length },
+            figures,
+          );
+        },
+      },
+      {
+        filter: ['img'],
+        visit(node, ctx) {
+          const parent = ctx.parent(node);
+          const container =
+            parent?.type === 'element' && parent.tagName === 'a'
+              ? ctx.parent(parent)
+              : parent;
+          // Standalone images are rebuilt as figures by the paragraph visitor.
+          if (isStandaloneImageParagraph(container)) return;
+
+          const properties = enhanceImageProperties(
+            node.properties ?? {},
+            ctx,
+            publicDirUrl,
+          );
+          for (const [key, value] of Object.entries(properties)) {
+            if (value !== node.properties?.[key]) {
+              ctx.setProperty(node, key, value);
+            }
+          }
+        },
+      },
+    ],
+    raw(node, ctx) {
+      const value = node.value ?? '';
+      const trimmed = value.trim();
+      if (!trimmed.toLowerCase().startsWith('<img')) return;
+
+      IMG_TAG.lastIndex = 0;
+      const tags = trimmed.match(IMG_TAG);
+      if (!tags) return;
+      // Only rewrite raw blocks that are made up entirely of images.
+      if (trimmed.replace(IMG_TAG, '').trim() !== '') return;
+
+      const parent = ctx.parent(node);
+      // A figure is flow content, so it may only replace a block-level image.
+      const asFigure = !(
+        parent?.type === 'element' && PHRASING_CONTAINERS.has(parent.tagName)
+      );
+
+      const html = tags
+        .map((tag) => {
+          const properties = enhanceImageProperties(
+            parseImageAttributes(tag),
+            ctx,
+            publicDirUrl,
+          );
+          return asFigure ? buildFigureHtml(properties) : buildImageHtml(properties);
+        })
+        .join('');
+
+      return {
+        type: 'raw',
+        value:
+          asFigure && tags.length > 1
+            ? `<div class="prose-gallery" data-count="${tags.length}">${html}</div>`
+            : html,
+      };
+    },
+  };
+}

--- a/src/scripts/headingAnchors.ts
+++ b/src/scripts/headingAnchors.ts
@@ -1,0 +1,97 @@
+const HEADING_SELECTOR = '.prose :is(h2, h3, h4, h5, h6)[id]';
+const RESET_DELAY = 1_600;
+const MARK = '#';
+const COPIED_MARK = '✓';
+const FAILED_MARK = '✕';
+
+let status: HTMLElement | undefined;
+
+const announce = (message: string) => {
+  if (!status) {
+    status = document.createElement('p');
+    status.className = 'visually-hidden';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    document.body.append(status);
+  }
+
+  status.textContent = message;
+  window.setTimeout(() => {
+    if (status?.textContent === message) status.textContent = '';
+  }, RESET_DELAY);
+};
+
+const copy = async (text: string): Promise<boolean> => {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Builds the link as a sibling of the heading, with the `#` hidden from
+ * assistive technology and a real (visually hidden) label in its place. Keeping
+ * the link out of the heading keeps screen reader heading lists clean.
+ * @see https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/
+ */
+const createAnchor = (heading: HTMLElement): HTMLAnchorElement => {
+  const anchor = document.createElement('a');
+  anchor.className = 'heading-anchor';
+  anchor.href = `#${encodeURIComponent(heading.id)}`;
+
+  const mark = document.createElement('span');
+  mark.className = 'heading-anchor-mark';
+  mark.setAttribute('aria-hidden', 'true');
+  mark.textContent = MARK;
+
+  const label = document.createElement('span');
+  label.className = 'visually-hidden';
+  label.textContent = `Copy link to section: ${heading.textContent?.trim() ?? heading.id}`;
+
+  anchor.append(mark, label);
+  return anchor;
+};
+
+/**
+ * Gives every article heading a `#` in the margin that copies its deep link.
+ * Headings are already addressable without JavaScript; this adds the visible
+ * handle and the clipboard shortcut.
+ */
+export function initHeadingAnchors(): void {
+  const headings = document.querySelectorAll<HTMLElement>(HEADING_SELECTOR);
+
+  for (const heading of headings) {
+    if (heading.parentElement?.classList.contains('heading-group')) continue;
+
+    const group = document.createElement('div');
+    group.className = 'heading-group';
+    group.dataset.level = heading.tagName.slice(1);
+    heading.replaceWith(group);
+
+    const anchor = createAnchor(heading);
+    group.append(heading, anchor);
+
+    anchor.addEventListener('click', async (event) => {
+      // Leave modified clicks alone so "open in new tab" and friends still work.
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      event.preventDefault();
+
+      const url = new URL(window.location.href);
+      url.hash = heading.id;
+      history.replaceState(null, '', url.hash);
+
+      const mark = anchor.querySelector('.heading-anchor-mark');
+      const copied = await copy(url.href);
+      anchor.dataset.copied = String(copied);
+      if (mark) mark.textContent = copied ? COPIED_MARK : FAILED_MARK;
+      announce(copied ? 'Link copied to clipboard' : 'Copy failed');
+
+      window.setTimeout(() => {
+        delete anchor.dataset.copied;
+        if (mark) mark.textContent = MARK;
+      }, RESET_DELAY);
+    });
+  }
+}

--- a/src/scripts/imageLightbox.ts
+++ b/src/scripts/imageLightbox.ts
@@ -1,0 +1,136 @@
+const ZOOMABLE_SELECTOR =
+  '.prose-figure:not([data-linked]) > img, .prose-figure:not([data-linked]) > picture > img';
+
+let dialog: HTMLDialogElement | undefined;
+let dialogImage: HTMLImageElement;
+let dialogCaption: HTMLElement;
+let dialogCounter: HTMLElement;
+let images: HTMLImageElement[] = [];
+let activeIndex = 0;
+
+const captionFor = (image: HTMLImageElement): string =>
+  image.closest('figure')?.querySelector('.prose-caption')?.textContent?.trim() ?? '';
+
+const sourceFor = (image: HTMLImageElement): string =>
+  image.dataset.zoomSrc || image.currentSrc || image.src;
+
+const render = () => {
+  const image = images[activeIndex];
+  if (!dialog || !image) return;
+
+  dialogImage.src = sourceFor(image);
+  dialogImage.alt = image.alt;
+  dialogCaption.textContent = captionFor(image);
+  dialogCounter.textContent = `${activeIndex + 1} / ${images.length}`;
+  dialog.dataset.single = images.length > 1 ? 'false' : 'true';
+};
+
+const step = (offset: number) => {
+  if (images.length < 2) return;
+  activeIndex = (activeIndex + offset + images.length) % images.length;
+  render();
+};
+
+const createDialog = (): HTMLDialogElement => {
+  const element = document.createElement('dialog');
+  element.className = 'lightbox';
+  element.setAttribute('aria-label', 'Image viewer');
+  element.innerHTML = `
+    <figure class="lightbox-figure">
+      <img class="lightbox-image" alt="" decoding="async" />
+      <figcaption class="lightbox-caption"></figcaption>
+    </figure>
+    <button class="lightbox-button lightbox-close" type="button" aria-label="Close image viewer">✕</button>
+    <button class="lightbox-button lightbox-previous" type="button" aria-label="Previous image">←</button>
+    <button class="lightbox-button lightbox-next" type="button" aria-label="Next image">→</button>
+    <p class="lightbox-counter" aria-hidden="true"></p>
+  `;
+
+  dialogImage = element.querySelector('.lightbox-image') as HTMLImageElement;
+  dialogCaption = element.querySelector('.lightbox-caption') as HTMLElement;
+  dialogCounter = element.querySelector('.lightbox-counter') as HTMLElement;
+
+  element
+    .querySelector('.lightbox-close')
+    ?.addEventListener('click', () => element.close());
+  element
+    .querySelector('.lightbox-previous')
+    ?.addEventListener('click', () => step(-1));
+  element
+    .querySelector('.lightbox-next')
+    ?.addEventListener('click', () => step(1));
+
+  element.addEventListener('click', (event) => {
+    // Only clicks on the surrounding backdrop area should dismiss the viewer.
+    if (event.target === element || event.target === dialogImage.parentElement) {
+      element.close();
+    }
+  });
+
+  element.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      step(1);
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      step(-1);
+    }
+  });
+
+  let swipeStartX = 0;
+  element.addEventListener(
+    'touchstart',
+    (event) => {
+      swipeStartX = event.changedTouches[0]?.clientX ?? 0;
+    },
+    { passive: true },
+  );
+  element.addEventListener(
+    'touchend',
+    (event) => {
+      const distance = (event.changedTouches[0]?.clientX ?? 0) - swipeStartX;
+      if (Math.abs(distance) > 60) step(distance < 0 ? 1 : -1);
+    },
+    { passive: true },
+  );
+
+  document.body.append(element);
+  return element;
+};
+
+const open = (index: number) => {
+  const image = images[index];
+  if (!image || !sourceFor(image)) return;
+
+  dialog ??= createDialog();
+  activeIndex = index;
+  render();
+  dialog.showModal();
+};
+
+/**
+ * Turns article images into an accessible click-to-zoom viewer. Everything it
+ * adds is progressive enhancement: without JavaScript the figures stay plain,
+ * static images.
+ */
+export function initImageLightbox(): void {
+  images = Array.from(document.querySelectorAll<HTMLImageElement>(ZOOMABLE_SELECTOR));
+  if (images.length === 0) return;
+
+  images.forEach((image, index) => {
+    image.dataset.zoomable = 'true';
+    image.tabIndex = 0;
+    image.setAttribute('role', 'button');
+    image.setAttribute(
+      'aria-label',
+      image.alt ? `Expand image: ${image.alt}` : 'Expand image',
+    );
+
+    image.addEventListener('click', () => open(index));
+    image.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      open(index);
+    });
+  });
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -536,6 +536,9 @@ input {
 
 .heading-group {
   position: relative;
+  /* h4-h6 inherit the prose size and leading; h2/h3 override below. */
+  --heading-size: 1.06rem;
+  --heading-leading: 1.72;
 }
 
 .heading-group > :is(h2, h3, h4, h5, h6) {
@@ -546,28 +549,36 @@ input {
   margin-top: 0;
 }
 
-/* The mark hangs in the page margin so it never interrupts the heading. */
-.heading-anchor {
-  display: inline-flex;
-  position: absolute;
-  top: 0;
-  right: calc(100% + 0.5rem);
-  align-items: center;
-  height: var(--heading-line, 1.9rem);
-  color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 0.95rem;
-  text-decoration: none;
-  transition: color 120ms ease;
-  opacity: 0.65;
-}
-
 .heading-group[data-level='2'] {
-  --heading-line: calc(1.6rem * 1.15);
+  --heading-size: 1.6rem;
+  --heading-leading: 1.15;
 }
 
 .heading-group[data-level='3'] {
-  --heading-line: calc(1.25rem * 1.15);
+  --heading-size: 1.25rem;
+  --heading-leading: 1.15;
+}
+
+/*
+ * The mark hangs in the page margin so it never interrupts the heading. It is
+ * sized and spaced from the heading's own type scale, and shares the heading's
+ * line box, so a single optical nudge centres it on the cap height at every
+ * level rather than needing a per-level correction.
+ */
+.heading-anchor {
+  display: block;
+  position: absolute;
+  top: 0;
+  right: calc(100% + 0.42em);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: calc(var(--heading-size) * 0.6);
+  line-height: calc(var(--heading-size) * var(--heading-leading));
+  text-decoration: none;
+  /* Optical nudge: centres the glyph on the cap height rather than the line box. */
+  transform: translateY(0.065em);
+  transition: color 120ms ease;
+  opacity: 0.65;
 }
 
 .heading-anchor:hover,
@@ -584,9 +595,9 @@ input {
 
 /* Confirmation swaps the glyph in place: no toast, no badge, no reflow. */
 .heading-anchor-mark {
-  display: inline-flex;
-  justify-content: center;
+  display: inline-block;
   width: 1ch;
+  text-align: center;
 }
 
 .heading-anchor[data-copied='true'] {
@@ -601,8 +612,7 @@ input {
 
 @media (max-width: 46rem) {
   .heading-anchor {
-    right: calc(100% + 0.3rem);
-    font-size: 0.85rem;
+    right: calc(100% + 0.3em);
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,11 @@
   --line: #cbc5b8;
   --rule-strong: var(--ink);
   --mark-filter: brightness(0);
+  --media-radius: 0.4rem;
+  --media-shadow:
+    0 1px 2px rgb(32 32 30 / 0.08), 0 10px 24px -14px rgb(32 32 30 / 0.45);
+  --media-shadow-raised:
+    0 2px 4px rgb(32 32 30 / 0.1), 0 16px 32px -16px rgb(32 32 30 / 0.55);
   --font-sans:
     Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -46,6 +51,10 @@
   --line: #5a5b54;
   --rule-strong: #8b8c83;
   --mark-filter: brightness(0) invert(1);
+  --media-shadow:
+    0 1px 2px rgb(0 0 0 / 0.3), 0 12px 28px -16px rgb(0 0 0 / 0.75);
+  --media-shadow-raised:
+    0 2px 4px rgb(0 0 0 / 0.35), 0 18px 36px -16px rgb(0 0 0 / 0.85);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -63,6 +72,10 @@
     --line: #5a5b54;
     --rule-strong: #8b8c83;
     --mark-filter: brightness(0) invert(1);
+    --media-shadow:
+      0 1px 2px rgb(0 0 0 / 0.3), 0 12px 28px -16px rgb(0 0 0 / 0.75);
+    --media-shadow-raised:
+      0 2px 4px rgb(0 0 0 / 0.35), 0 18px 36px -16px rgb(0 0 0 / 0.85);
   }
 }
 
@@ -517,6 +530,94 @@ input {
   line-height: 1.15;
 }
 
+.prose :is(h2, h3, h4, h5, h6)[id] {
+  scroll-margin-block-start: 1.5rem;
+}
+
+.heading-group {
+  position: relative;
+}
+
+.heading-group > :is(h2, h3, h4, h5, h6) {
+  margin-bottom: 0;
+}
+
+.prose > .heading-group:first-child > :is(h2, h3, h4, h5, h6) {
+  margin-top: 0;
+}
+
+/* The mark hangs in the page margin so it never interrupts the heading. */
+.heading-anchor {
+  display: inline-flex;
+  position: absolute;
+  top: 0;
+  right: calc(100% + 0.5rem);
+  align-items: center;
+  height: var(--heading-line, 1.9rem);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: color 120ms ease;
+  opacity: 0.65;
+}
+
+.heading-group[data-level='2'] {
+  --heading-line: calc(1.6rem * 1.15);
+}
+
+.heading-group[data-level='3'] {
+  --heading-line: calc(1.25rem * 1.15);
+}
+
+.heading-anchor:hover,
+.heading-anchor:focus-visible {
+  color: var(--ink);
+  text-decoration: none;
+  opacity: 1;
+}
+
+.heading-anchor:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+/* Confirmation swaps the glyph in place: no toast, no badge, no reflow. */
+.heading-anchor-mark {
+  display: inline-flex;
+  justify-content: center;
+  width: 1ch;
+}
+
+.heading-anchor[data-copied='true'] {
+  color: var(--ink);
+  opacity: 1;
+}
+
+.heading-anchor[data-copied='false'] {
+  color: var(--muted);
+  opacity: 1;
+}
+
+@media (max-width: 46rem) {
+  .heading-anchor {
+    right: calc(100% + 0.3rem);
+    font-size: 0.85rem;
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 .prose h2 {
   font-size: 1.6rem;
 }
@@ -530,6 +631,74 @@ input {
   max-width: 100%;
   height: auto;
   border: 1px solid var(--line);
+  border-radius: var(--media-radius);
+}
+
+.prose-figure {
+  display: block;
+  margin: 0;
+  text-align: center;
+}
+
+.prose-figure > a,
+.prose-figure > picture {
+  display: block;
+  line-height: 0;
+}
+
+.prose-figure img {
+  width: auto;
+  margin-inline: auto;
+  background: var(--paper-deep);
+  box-shadow: var(--media-shadow);
+}
+
+.prose-figure:not([data-orientation='landscape']) img {
+  max-height: min(30rem, 72vh);
+}
+
+.prose-caption {
+  max-width: 32rem;
+  margin: 0.7rem auto 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  text-align: center;
+  text-wrap: balance;
+}
+
+.prose-gallery {
+  display: grid;
+  align-items: end;
+  justify-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(min(11rem, 100%), 1fr));
+  gap: 1.4rem 1rem;
+}
+
+.prose-gallery .prose-figure:not([data-orientation='landscape']) img {
+  max-height: min(24rem, 60vh);
+}
+
+.prose-figure img[data-zoomable] {
+  cursor: zoom-in;
+}
+
+@media (hover: hover) and (prefers-reduced-motion: no-preference) {
+  .prose-figure img[data-zoomable] {
+    transition:
+      box-shadow 180ms ease,
+      transform 180ms ease;
+  }
+
+  .prose-figure img[data-zoomable]:hover {
+    box-shadow: var(--media-shadow-raised);
+    transform: translateY(-2px);
+  }
+}
+
+.prose-figure img[data-zoomable]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .prose iframe,
@@ -877,6 +1046,181 @@ input {
 
 .copy-status:empty {
   visibility: hidden;
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  display: none;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  max-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: #f4f1ea;
+}
+
+.lightbox[open] {
+  display: grid;
+  place-items: center;
+}
+
+.lightbox::backdrop {
+  background: rgb(16 16 15 / 0.88);
+}
+
+.lightbox-figure {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.9rem;
+  margin: 0;
+  padding: clamp(1rem, 4vw, 2.5rem);
+}
+
+.lightbox-image {
+  display: block;
+  max-width: min(96vw, 1400px);
+  max-height: 82dvh;
+  border-radius: var(--media-radius);
+  background: rgb(255 255 255 / 0.06);
+  object-fit: contain;
+}
+
+.lightbox-caption {
+  max-width: min(46rem, 90vw);
+  color: rgb(244 241 234 / 0.78);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  text-align: center;
+  text-wrap: balance;
+}
+
+.lightbox-caption:empty {
+  display: none;
+}
+
+.lightbox-button {
+  display: grid;
+  position: absolute;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border: 1px solid rgb(244 241 234 / 0.25);
+  border-radius: 50%;
+  background: rgb(16 16 15 / 0.6);
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.lightbox-button:hover {
+  background: rgb(16 16 15 / 0.9);
+  border-color: rgb(244 241 234 / 0.55);
+}
+
+.lightbox-button:focus-visible {
+  outline: 2px solid #f4f1ea;
+  outline-offset: 2px;
+}
+
+.lightbox-close {
+  top: 1rem;
+  right: 1rem;
+}
+
+.lightbox-previous {
+  top: 50%;
+  left: 1rem;
+  transform: translateY(-50%);
+}
+
+.lightbox-next {
+  top: 50%;
+  right: 1rem;
+  transform: translateY(-50%);
+}
+
+.lightbox[data-single="true"] .lightbox-previous,
+.lightbox[data-single="true"] .lightbox-next {
+  display: none;
+}
+
+.lightbox-counter {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  color: rgb(244 241 234 / 0.62);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  transform: translateX(-50%);
+}
+
+.lightbox[data-single="true"] .lightbox-counter {
+  display: none;
+}
+
+html:has(.lightbox[open]) {
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .lightbox[open] {
+    animation: lightbox-fade 180ms ease-out;
+  }
+
+  .lightbox[open] .lightbox-image {
+    animation: lightbox-rise 220ms cubic-bezier(0.2, 0.8, 0.3, 1);
+  }
+}
+
+@keyframes lightbox-fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes lightbox-rise {
+  from {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+}
+
+@media (max-width: 34rem) {
+  .lightbox-figure {
+    padding: 4rem 0.75rem 5.25rem;
+  }
+
+  .lightbox-image {
+    max-height: 66dvh;
+  }
+
+  .lightbox-previous,
+  .lightbox-next {
+    top: auto;
+    bottom: 1rem;
+    transform: none;
+  }
+
+  .lightbox-previous {
+    left: calc(50% - 5.5rem);
+  }
+
+  .lightbox-next {
+    right: calc(50% - 5.5rem);
+  }
+
+  .lightbox-counter {
+    bottom: 2.15rem;
+  }
 }
 
 @media (max-width: 34rem) {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -811,3 +811,302 @@ test('highlighted prose links use dark underlines in dark mode', async ({
   expect(colors.underline).toBe(colors.text);
   expect(colors.underline).toBe('rgb(32, 32, 30)');
 });
+
+test('post images become captioned figures with layout-stable dimensions', async ({
+  page,
+}) => {
+  await page.goto('/mapcalipers/');
+
+  const figures = page.locator('.prose-figure');
+  await expect(figures.first()).toBeVisible();
+
+  const images = await page.locator('.prose-figure img').evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const image = node as HTMLImageElement;
+      return {
+        alt: image.alt,
+        width: image.getAttribute('width'),
+        height: image.getAttribute('height'),
+        loading: image.getAttribute('loading'),
+        decoding: image.getAttribute('decoding'),
+      };
+    }),
+  );
+
+  expect(images.length).toBeGreaterThan(1);
+  for (const image of images) {
+    expect(image.alt).not.toBe('');
+    expect(Number(image.width)).toBeGreaterThan(0);
+    expect(Number(image.height)).toBeGreaterThan(0);
+  }
+
+  // Only the first image is eager, so the rest never block the initial render.
+  expect(images[0].loading).toBe('eager');
+  expect(images.slice(1).every((image) => image.loading === 'lazy')).toBe(true);
+  expect(images.slice(1).every((image) => image.decoding === 'async')).toBe(true);
+
+  await expect(page.locator('.prose-caption').first()).toHaveText(
+    /Drop points to trace the play area/,
+  );
+});
+
+test('adjacent images collapse into a single responsive gallery row', async ({
+  page,
+}) => {
+  await page.goto('/mapcalipers/');
+
+  const gallery = page.locator('.prose-gallery');
+  await expect(gallery).toHaveAttribute('data-count', '3');
+
+  const tops = await gallery
+    .locator('.prose-figure')
+    .evaluateAll((nodes) => nodes.map((node) => node.getBoundingClientRect().top));
+  expect(tops).toHaveLength(3);
+  expect(new Set(tops).size).toBe(1);
+
+  await page.setViewportSize({ width: 380, height: 900 });
+  const stackedTops = await gallery
+    .locator('.prose-figure')
+    .evaluateAll((nodes) => nodes.map((node) => node.getBoundingClientRect().top));
+  expect(new Set(stackedTops).size).toBe(3);
+});
+
+test('figures open an accessible lightbox that navigates and closes', async ({
+  page,
+}) => {
+  await page.goto('/mapcalipers/');
+
+  const trigger = page.locator('.prose-gallery img').first();
+  await expect(trigger).toHaveAttribute('role', 'button');
+  await expect(trigger).toHaveAttribute('aria-label', /^Expand image: /);
+
+  await trigger.focus();
+  await page.keyboard.press('Enter');
+
+  const lightbox = page.locator('dialog.lightbox');
+  await expect(lightbox).toBeVisible();
+  await expect(page.locator('.lightbox-caption')).toHaveText(
+    /Radar: rule out everything/,
+  );
+
+  await page.keyboard.press('ArrowRight');
+  await expect(page.locator('.lightbox-caption')).toHaveText(
+    /Thermometer: slice the play area/,
+  );
+
+  await page.locator('.lightbox-close').click();
+  await expect(lightbox).toBeHidden();
+  await expect(trigger).toBeFocused();
+});
+
+test('linked images stay links instead of opening the lightbox', async ({
+  page,
+}) => {
+  await page.goto('/mapcalipers/');
+
+  const linkedImages = page.locator('.prose-figure[data-linked] img');
+  expect(await linkedImages.count()).toBe(
+    await page.locator('.prose-figure[data-linked] img:not([data-zoomable])').count(),
+  );
+});
+
+test('figure images never distort their aspect ratio', async ({ page }) => {
+  await page.goto('/mapcalipers/');
+  // Lazy images only decode once they are scrolled near the viewport.
+  await page.evaluate(async () => {
+    for (let y = 0; y < document.body.scrollHeight; y += 500) {
+      window.scrollTo(0, y);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+    }
+  });
+  await expect
+    .poll(() =>
+      page
+        .locator('.prose img')
+        .evaluateAll((nodes) =>
+          nodes.every((node) => (node as HTMLImageElement).naturalWidth > 0),
+        ),
+    )
+    .toBe(true);
+
+  const ratios = await page.locator('.prose img').evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const image = node as HTMLImageElement;
+      return {
+        src: image.getAttribute('src'),
+        natural: image.naturalWidth / image.naturalHeight,
+        // clientWidth/Height exclude the border, unlike the border-box rect.
+        rendered: image.clientWidth / image.clientHeight,
+      };
+    }),
+  );
+
+  expect(ratios.length).toBeGreaterThan(0);
+  for (const { src, natural, rendered } of ratios) {
+    expect(
+      Math.abs(natural - rendered) / natural,
+      `${src} renders at ${rendered.toFixed(3)} but is naturally ${natural.toFixed(3)}`,
+    ).toBeLessThan(0.02);
+  }
+});
+
+test('section headings expose deep links that copy to the clipboard', async ({
+  page,
+  context,
+}) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.goto('/mapcalipers/');
+
+  const anchor = page.locator('.heading-group:has(h3#tools) .heading-anchor');
+
+  await expect(anchor).toBeVisible();
+  await expect(anchor).toHaveAttribute('href', '#tools');
+  await expect(anchor).toHaveText('#Copy link to section: Tools');
+
+  await anchor.click();
+
+  await expect(page).toHaveURL(/#tools$/);
+  await expect(anchor).toHaveAttribute('data-copied', 'true');
+  // Confirmation swaps the glyph in place rather than opening a badge.
+  await expect(anchor.locator('.heading-anchor-mark')).toHaveText('✓');
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(
+    `${new URL(page.url()).origin}/mapcalipers/#tools`,
+  );
+  await expect(page.locator('[role="status"]').last()).toHaveText(
+    'Link copied to clipboard',
+  );
+});
+
+test('heading anchors stay out of the heading for screen readers', async ({
+  page,
+}) => {
+  await page.goto('/mapcalipers/');
+
+  const details = await page
+    .locator('.prose :is(h2, h3, h4, h5, h6)')
+    .evaluateAll((nodes) =>
+      nodes.map((node) => {
+        const anchor = node.parentElement?.querySelector(':scope > .heading-anchor');
+        return {
+          id: node.id,
+          // The link must not live inside the heading, or screen reader
+          // heading lists read the anchor as part of the heading text.
+          anchorsInside: node.querySelectorAll('.heading-anchor').length,
+          text: node.textContent?.trim(),
+          hasSiblingAnchor: Boolean(anchor),
+          markHidden:
+            anchor?.querySelector('.heading-anchor-mark')?.getAttribute('aria-hidden') ===
+            'true',
+          hasVisibleLabel: Boolean(anchor?.querySelector('.visually-hidden')?.textContent),
+          usesAriaLabel: anchor?.hasAttribute('aria-label') ?? false,
+        };
+      }),
+    );
+
+  expect(details.length).toBeGreaterThan(0);
+  for (const heading of details) {
+    expect(heading.anchorsInside, heading.id).toBe(0);
+    expect(heading.hasSiblingAnchor, heading.id).toBe(true);
+    expect(heading.markHidden, heading.id).toBe(true);
+    expect(heading.hasVisibleLabel, heading.id).toBe(true);
+    // aria-label is skipped by some translation tools, so real text is used.
+    expect(heading.usesAriaLabel, heading.id).toBe(false);
+    expect(heading.text, heading.id).not.toContain('#');
+  }
+});
+
+test('every article heading is addressable and anchored exactly once', async ({
+  page,
+}) => {
+  await page.goto('/mapcalipers/');
+
+  const headings = await page
+    .locator('.prose :is(h2, h3, h4, h5, h6)')
+    .evaluateAll((nodes) =>
+      nodes.map((node) => ({
+        id: node.id,
+        anchors:
+          node.parentElement?.querySelectorAll(':scope > .heading-anchor').length ?? 0,
+      })),
+    );
+
+  expect(headings.length).toBeGreaterThan(0);
+  expect(headings.every((heading) => heading.id !== '')).toBe(true);
+  expect(headings.every((heading) => heading.anchors === 1)).toBe(true);
+  expect(new Set(headings.map((heading) => heading.id)).size).toBe(headings.length);
+});
+
+test('loading a heading deep link scrolls that section into view', async ({
+  page,
+}) => {
+  await page.goto('/mapcalipers/#self-hosting');
+
+  const box = await page.locator('h2#self-hosting').boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeLessThan(100);
+});
+
+test('article images are served as resized WebP with the original as fallback', async ({
+  page,
+}) => {
+  await page.goto('/mapcalipers/');
+  await page.locator('.prose img').first().scrollIntoViewIfNeeded();
+
+  const images = await page.locator('.prose-figure img').evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const image = node as HTMLImageElement;
+      return {
+        src: image.getAttribute('src') ?? '',
+        inPicture: image.parentElement?.tagName === 'PICTURE',
+        webpSource:
+          image.parentElement?.querySelector('source')?.getAttribute('type') ?? '',
+        srcset: image.parentElement?.querySelector('source')?.getAttribute('srcset') ?? '',
+        sizes: image.getAttribute('sizes') ?? '',
+        zoomSrc: image.dataset.zoomSrc ?? '',
+      };
+    }),
+  );
+
+  expect(images.length).toBeGreaterThan(0);
+  for (const image of images) {
+    expect(image.inPicture, image.src).toBe(true);
+    expect(image.webpSource, image.src).toBe('image/webp');
+    expect(image.srcset, image.src).toMatch(/\.webp \d+w/);
+    expect(image.sizes, image.src).not.toBe('');
+    // The viewer opens an optimized variant rather than the full-size original.
+    expect(image.zoomSrc, image.src).toMatch(/\.webp$/);
+    // The untouched original stays as the fallback for browsers without WebP.
+    expect(image.src, image.src).not.toMatch(/\.webp$/);
+  }
+
+  const chosen = await page
+    .locator('.prose-figure img')
+    .first()
+    .evaluate((node) => (node as HTMLImageElement).currentSrc);
+  expect(chosen).toMatch(/\.webp$/);
+});
+
+test('the optimized variant is a fraction of the original download', async ({
+  page,
+  request,
+}) => {
+  await page.goto('/mapcalipers/');
+
+  const { original, variant } = await page
+    .locator('.prose-figure img')
+    .first()
+    .evaluate((node) => {
+      const image = node as HTMLImageElement;
+      return { original: image.getAttribute('src')!, variant: image.currentSrc };
+    });
+
+  const [originalResponse, variantResponse] = await Promise.all([
+    request.get(original),
+    request.get(variant),
+  ]);
+  const originalBytes = (await originalResponse.body()).length;
+  const variantBytes = (await variantResponse.body()).length;
+
+  expect(variantBytes).toBeLessThan(originalBytes * 0.25);
+});

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -1110,3 +1110,69 @@ test('the optimized variant is a fraction of the original download', async ({
 
   expect(variantBytes).toBeLessThan(originalBytes * 0.25);
 });
+
+test('the heading mark is proportional and optically centred at every level', async ({
+  page,
+}) => {
+  await page.goto('/HabitBridge/');
+
+  const groups = await page.locator('.heading-group').evaluateAll((nodes) => {
+    // Font metrics for the exact rendered font, so the check follows whatever
+    // the browser actually painted rather than a hard-coded number.
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d')!;
+    const metricsFor = (element: Element, text: string) => {
+      const style = getComputedStyle(element);
+      context.font = `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+      const measured = context.measureText(text);
+      const lineHeight = Number.parseFloat(style.lineHeight);
+      const content =
+        measured.fontBoundingBoxAscent + measured.fontBoundingBoxDescent;
+      return {
+        fontSize: Number.parseFloat(style.fontSize),
+        // Where the first baseline sits inside this element's box.
+        baselineOffset:
+          (lineHeight - content) / 2 + measured.fontBoundingBoxAscent,
+        inkAscent: measured.actualBoundingBoxAscent,
+        inkDescent: measured.actualBoundingBoxDescent,
+      };
+    };
+
+    return nodes.map((group) => {
+      const heading = group.querySelector('h2, h3, h4, h5, h6')!;
+      const anchor = group.querySelector('.heading-anchor')!;
+      const mark = anchor.querySelector('.heading-anchor-mark')!;
+
+      // "H" is a flat-topped cap, so its ink is the cap height exactly.
+      const headingMetrics = metricsFor(heading, 'H');
+      const markMetrics = metricsFor(mark, '#');
+      const headingBaseline =
+        heading.getBoundingClientRect().top + headingMetrics.baselineOffset;
+      const markBaseline =
+        anchor.getBoundingClientRect().top + markMetrics.baselineOffset;
+
+      const capCentre = headingBaseline - headingMetrics.inkAscent / 2;
+      const markCentre =
+        markBaseline - (markMetrics.inkAscent - markMetrics.inkDescent) / 2;
+
+      return {
+        level: (group as HTMLElement).dataset.level,
+        sizeRatio: markMetrics.fontSize / headingMetrics.fontSize,
+        centreOffset: markCentre - capCentre,
+      };
+    });
+  });
+
+  expect(groups.length).toBeGreaterThan(0);
+  const levels = new Set(groups.map((group) => group.level));
+  expect(levels.size).toBeGreaterThan(1);
+
+  for (const group of groups) {
+    // The mark scales with its heading instead of being a fixed size.
+    expect(group.sizeRatio, `h${group.level} size ratio`).toBeCloseTo(0.6, 1);
+    expect(
+      Math.abs(group.centreOffset),
+      `h${group.level} is ${group.centreOffset.toFixed(2)}px off centre`,
+    ).toBeLessThan(1.5);
+  }
+});


### PR DESCRIPTION
Image-heavy posts rendered as long columns of raw, full-resolution images — `/sewing/` alone shipped **82 MB**. This adds a proper figure system, deep-linkable headings, and a build-time image pipeline that cuts page weight by 95–99%.

## Presentation

- Standalone images become `<figure>` elements; Markdown image titles render as visible captions, and adjacent images collapse into a responsive gallery grid.
- Images carry intrinsic `width`/`height` read from disk at build time, so there is **no layout shift** — verified that reserved placeholder heights match loaded heights exactly.
- First image loads `eager`/`fetchpriority=high` (it's the LCP element); the rest are `lazy`.
- Click-to-zoom viewer built on `<dialog>`, with keyboard, swipe and backdrop dismissal. Progressive enhancement — without JS the figures stay plain static images.

A bug worth noting: because the pipeline injects `width`/`height`, CSS `width` was no longer `auto`, so a `max-height` cap clamped height *without* recomputing width and squashed **every** figure. Fixed with `width: auto`; all 201 images across 48 pages now render at their true aspect ratio.

## Deep links

Every article heading gets a `#` in the margin that copies its link, confirming with an in-place glyph swap (no toast, no badge, no reflow).

The anchor is a **sibling** of the heading with visually hidden label text rather than an `aria-label`, so screen-reader heading lists stay clean and translation tools can reach the label — following [Amber Wilson's accessible anchor links](https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/).

The mark is sized from the heading's own type scale and shares its line box, so a single optical nudge centres it on the cap height at every level:

| | before | after |
|---|---|---|
| h2 size ratio (mark ink ÷ cap height) | 0.58 | 0.59 |
| h3 size ratio | 0.72 | 0.57 |
| h4 size ratio | — | 0.61 |
| offset from cap centre | 2.75–3.5px high | **0.00–0.13px** |

## Performance

A build integration rewrites built `<img>` tags into `<picture>` with resized WebP variants, keeping the untouched original as the fallback. Astro's optimizer deliberately skips `public/`, so this post-processes the finished HTML — nothing moves in the source tree and every URL stays valid.

| Page | Before | After | Saved |
|---|---|---|---|
| `/sewing/` | 82.2 MB | **2.80 MB** | 96.6% |
| `/geo-fellowship/` | 67.6 MB | **0.29 MB** | 99.6% |
| `/HabitBridge/` | 27.3 MB | **1.89 MB** | 93.1% |
| `/mapcalipers/` | 12.5 MB | **0.31 MB** | 97.5% |
| `/hitch-to-paris/` | 11.8 MB | **0.34 MB** | 97.1% |
| `/homelab/` | 5.4 MB | **0.24 MB** | 95.6% |

- `sizes` is computed from the actual CSS caps (column width, height caps, gallery halving) rather than guessed, so browsers don't over-fetch.
- Animated GIFs are re-encoded too — `pencil.gif` 76 MB → 3.6 MB, `ha.gif` 24 MB → 0.9 MB. That's what rescued the two worst pages without needing ffmpeg.
- The lightbox opens an optimized variant instead of the multi-megabyte original.
- Variants are cached between builds, since `test:e2e` builds every run: **cold 40s, warm 2.6s**.

## Content

An audit of all 96 pages found the new system wasn't universally adopted:

- **68 headings on 9 pages** were written as raw HTML (`<h2>Prereqs</h2>`), which Astro's heading-id pass never sees — no id, no deep link, no TOC entry. Converted 71 to Markdown.
- **HabitBridge** bypassed the figure system entirely with nested flex `<div>`s — 11 images with no dimensions, no lazy loading, 4 with no `alt`.
- **10 images** were trapped inside text paragraphs by Jekyll-era `<br><br>` spacing hacks.
- **8 hand-rolled `<small>` captions** became real `<figcaption>`s.

Final audit: **205/205 images in figures, 404/404 headings anchored**, zero distorted, broken, oversized or unlabelled images.

## Validation

`astro check` clean · 153 pages build · **39/39 Playwright tests pass** (13 new)

New tests cover the figure/caption structure, gallery reflow, lightbox keyboard flow, aspect-ratio integrity, the `<picture>`/WebP output, anchor accessibility structure, and the mark's size ratio and optical centring — the last of which caught a real 4px h4 leading bug during development.

## Not included

Deliberately left out of scope: `og:image` and `og:type="article"` for posts, `twitter:card`, and a sitemap. Happy to follow up.
